### PR TITLE
add policyreferenceid for initiative remediation

### DIFF
--- a/Scripts/Operations/Create-AzRemediationTasks.ps1
+++ b/Scripts/Operations/Create-AzRemediationTasks.ps1
@@ -17,6 +17,7 @@ param(
 . "$PSScriptRoot/../Config/Initialize-Environment.ps1"
 . "$PSScriptRoot/../Config/Get-AzEnvironmentDefinitions.ps1"
 
+
 if ($suppressCollectionInformation.IsPresent) {
     $InformationPreference = "SilentContinue"
 }
@@ -78,16 +79,26 @@ else {
             $assignment = $assignments[$assignmentId]
             $remediationTaskDefinitions = $assignment.remediationTasks
             Write-Information "    Assignment ""$($assignment.assignmentDisplayName)"", Resources=$($assignment.nonCompliantResources)"
+            $isInitiativeAssignment = $false
             if ($assignment.initiativeId -ne "") {
                 Write-Information "        Assigned Initiative ""$($assignment.initiativeDisplayName)"""
+                $isInitiativeAssignment = $true
             }
             foreach ($remediationTaskDefinition in $remediationTaskDefinitions) {
                 $info = $remediationTaskDefinition.info
                 Write-Information "        Policy=""$($info.policyDisplayName)"", Resources=$($info.nonCompliantResources)"
+                
+                if ($isInitiativeAssignment){
+                    $remediationTaskDefinition.splat["definition-reference-id"] = $info.policyDefinitionReferenceId
+                }
+
+                $remediationTaskDefinition.splat
+                
                 Invoke-AzCli policy remediation create -Splat $remediationTaskDefinition.splat -SuppressOutput
             }
         }
         Write-Information "---------------------------------------------------------------------------------------------------"
     }
 }
+
 Write-Information ""


### PR DESCRIPTION
Hello,

This is a fix to solve an error I was getting when using the Operations script Create-AzRemediationTasks.ps1 on initiatives. It works properly on single policy assignment, but fails with the error below when used on a policy set assignment: 

```
ERROR: (InvalidCreateRemediationRequest) The request to create remediation 'storage-hardening' is invalid. The policy assignment '/subscriptions/ee273d6a-65eb-4cea-a257-0767fda87423/providers/microsoft.authorization/policyassignments/storage-hardening' assigns a policy set definition. Remediations must specify a single policy definition reference ID within the policy set definition.
Code: InvalidCreateRemediationRequest
```

I have tested this fix on my end and it is working for initiative assignments. 
