### PR TITLE
fix remediation for initiative

### DIFF
--- a/Scripts/Helpers/Get-AzAssignmentsAtScopeRecursive.ps1
+++ b/Scripts/Helpers/Get-AzAssignmentsAtScopeRecursive.ps1
@@ -114,10 +114,10 @@ function Add-Assignments {
                         $numberOfAssignmentsWithRemediations++
                         $remediationTasks = @()
                         $initiativeDefinitionId = $summary.policySetDefinitionId
-                        $initiativeDefinition = $null
+
                         if ($initiativeDefinitionId -ne "") {
                             $initiativeName = $initiativeDefinitionId.Split('/')[-1]
-                            $initiativeDefinition = $allInitiativeDefinitions[$initiativeName]
+
                             # Write-Information "        Assigned Initiative '$($initiativeDefinition.displayName)'"
                         }
                         foreach ($policyDefinition in $summary.policyDefinitions) {
@@ -141,7 +141,7 @@ function Add-Assignments {
                                 $splat.Add("policy-assignment", $id)
                                 $assignmentDisplayName = $assignment.name
                                 $taskName = $assignmentDisplayName -replace '\s', '-'
-                                if ($null -eq $initiativeDefinition) {
+                                if ($null -eq $initiativeDefinitionId) {
                                     # Single Policy
                                     $splat.Add("name", $taskName)
                                 }
@@ -162,10 +162,10 @@ function Add-Assignments {
                             remediationTasks      = $remediationTasks
                             nonCompliantResources = $assignmentResult.nonCompliantResources
                         }
-                        if ($null -ne $initiativeDefinition) {
+                        if ($null -ne $initiativeDefinitionId) {
                             $assignmentRemediation += @{
                                 initiativeName        = $initiativeName
-                                initiativeDisplayName = $initiativeDefinition.displayName
+
                             }
                         }
                         if ($remediations.ContainsKey($scope)) {

--- a/Scripts/Operations/Create-AzRemediationTasks.ps1
+++ b/Scripts/Operations/Create-AzRemediationTasks.ps1
@@ -79,7 +79,7 @@ else {
             $remediationTaskDefinitions = $assignment.remediationTasks
             Write-Information "    Assignment ""$($assignment.assignmentDisplayName)"", Resources=$($assignment.nonCompliantResources)"
             if ($assignment.initiativeId -ne "") {
-                Write-Information "        Assigned Initiative ""$($assignment.initiativeDisplayName)"""
+                Write-Information "        Assigned Initiative ""$($assignment.initiativeName)"""
             }
             foreach ($remediationTaskDefinition in $remediationTaskDefinitions) {
                 $info = $remediationTaskDefinition.info


### PR DESCRIPTION
We encountered an issue when trying to use the CreateRemediationTask script on a scope that contained existing initiatives assignments that need remediation.

When executing the script, the error below was returned: 

```
ERROR: (InvalidCreateRemediationRequest) The request to create remediation 'storage-hardening' is invalid. The policy assignment '/subscriptions/ee273d6a-65eb-4cea-a257-0767fda87423/providers/microsoft.authorization/policyassignments/storage-hardening' assigns a policy set definition. Remediations must specify a single policy definition reference ID within the policy set definition.
Code: InvalidCreateRemediationRequest
```

After further analysis of the code, we realized that the policy definition reference ID argument was not properly passed to the 'az policy remediation create' cli command. The code treated the remediation as a single policy assignment instead of a policy set (initiative). 

The $initiativeDefinition object was always null and the code is checking for this value to determine whether it is an initiative or not. However the initiativeDefinitionId is present in the $summary object. 
We noticed that $allInitiativeDefinitions was empty (because the definitions are 1 level higher than the current scope), therefore the $initiativeDefinition object was always null.

We removed the logic that depends on the $allInitiativeDefinitions array as it was only used for the initiativeDisplayName, and we propose to replace it with the initiativeName which is already present in the $summary object.