### PR TITLE
fix path for linux agent  which are case sensitive

### DIFF
--- a/Scripts/Config/Initialize-Environment.ps1
+++ b/Scripts/Config/Initialize-Environment.ps1
@@ -5,7 +5,7 @@ function Initialize-Environment {
     param (
         [parameter(Mandatory = $false, Position = 0)] [string] $environmentSelector = $null
     )
-    . "$PSScriptRoot/Get-AzenvironmentDefinitions.ps1"
+    . "$PSScriptRoot/Get-AzEnvironmentDefinitions.ps1"
 
     $environmentDefinitions, $defaultSubscriptionId = Get-AzEnvironmentDefinitions
     $environment = $null


### PR DESCRIPTION
when running the script on a linux agent, we receive the following error message

```
Initialize-Environment : The term '/home/vsts/work/1/s/Scripts/Config/Get-AzenvironmentDefinitions.ps1' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At /home/vsts/work/1/s/Scripts/Operations/Create-AzRemediationTasks.ps1:28 char:40
+ …  $defaultSubscriptionId = Initialize-Environment $environmentSelector
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (/home/vsts/work/1/s…mentDefinitions.ps1:String) [Initialize-Environment], CommandNotFoundException
+ FullyQualifiedErrorId : CommandNotFoundException,Initialize-Environment
##[error]Script failed with exit code: 1

```

On linux powershell, dot sourcing file must respect the case sensitiveness