### PR TITLE
child management groups (if any), are part of the exemptions

### DIFF
--- a/Scripts/Helpers/Get-AzPolicyNotScope.ps1
+++ b/Scripts/Helpers/Get-AzPolicyNotScope.ps1
@@ -47,7 +47,7 @@ function Get-NotScope {
                                 $notScope += "$($child.id)"
                                 # Write-Host "##[debug] notScope added $($child.Id)"
                             }
-                            elseif ($child.type -eq "/providers/Microsoft.Management/managementGroups") {
+                            elseif ($child.type -eq "Microsoft.Management/managementGroups") {
                                 $null = $queuedManagementGroups.Enqueue($child)
                                 # Write-Host "##[debug] enqueue child $($child.Id)"
                             }


### PR DESCRIPTION
The value of the $child.Type is splitted and doesn't contain the prefix "/providers/". This cause the management Group to be added in the $subscriptionIds. Therefore added to the exemption list of the assignment.