### PR TITLE
Updated role name

### DIFF
--- a/Pipeline/README.md
+++ b/Pipeline/README.md
@@ -63,8 +63,8 @@ Create service connections for each of your environments and require minimum rol
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | sc-pac-dev | devAllStage  | Owner ||||
 | sc-pac-test    | testAllStage || Owner |||
-| sc-pac-plan-1 | prodPlanFeatureStage <br/> prodPlanMainStage ||| Policy Reader<br/>Security Reader ||
-| sc-pac-plan-2 | prodPlanFeatureStage <br/> prodPlanMainStage |||| Policy Reader<br/>Security Reader |
+| sc-pac-plan-1 | prodPlanFeatureStage <br/> prodPlanMainStage ||| EPAC Policy Reader<br/>Security Reader ||
+| sc-pac-plan-2 | prodPlanFeatureStage <br/> prodPlanMainStage |||| EPAC Policy Reader<br/>Security Reader |
 | sc-pac-prod-1 | prodDeployStage-1 ||| Policy Contributor<br/>Security Reader ||
 | sc-pac-prod-2 | prodDeployStage-2 |||| Policy Contributor<br/>Security Reader |
 | sc-pac-roles-1 | prodRolesStage-1 ||| User Administrator<br/>Security Reader ||

--- a/README.md
+++ b/README.md
@@ -103,9 +103,12 @@ The solution has a starter kit (folder `StarterKit`). Copy the contents of the `
 ### EPAC Policy Reader role (custom)
 
 Create a custom role to be used by the planing stages' service connections **EPAC Policy Reader role**. Script `./Scripts/Operations/New-AzPolicyReaderRole.ps1` will create the role at the scope defined in `global-settings.json`. It will contain:
-   - `Microsoft.Authorization/policyAssignments/read`
-   - `Microsoft.Authorization/policyDefinitions/read`
-   - `Microsoft.Authorization/policySetDefinitions/read`
+   - `Microsoft.Authorization/policyassignments/read`
+   - `Microsoft.Authorization/policydefinitions/read`
+   - `Microsoft.Authorization/policyexemptions/read`
+   - `Microsoft.Authorization/policysetdefinitions/read`
+   - `Microsoft.PolicyInsights/*`
+   - `Microsoft.Support/*`
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In this file:
 - [GitHub repository: How to clone or fork, update and contribute](#github-repository-how-to-clone-or-fork-update-and-contribute)
 - [Quick Start](#quick-start)
   - [Starter Kit](#starter-kit)
-  - [Policy Reader role (custom)](#policy-reader-role-custom)
+  - [EPAC Policy Reader role (custom)](#policy-reader-role-custom)
   - [Required Management Groups and subscriptions](#required-management-groups-and-subscriptions)
   - [Service connections for DevOps CI/CD](#service-connections-for-devops-cicd)
   - [EPAC environments setup](#epac-environments-setup)
@@ -100,9 +100,9 @@ This quick is meant as an overview. We highly recommend that you read the entire
 
 The solution has a starter kit (folder `StarterKit`). Copy the contents of the `StarterKit/Definitions` folder to `Definitions` folder. Copy the pipeline definition(s) for your DevOps deployment solution (for example: Azure DevOps, GitHub) to the `Pipeline` folder.
 
-### Policy Reader role (custom)
+### EPAC Policy Reader role (custom)
 
-Create a custom role to be used by the planing stages' service connections **Policy Reader role**. Script `./Scripts/Operations/New-AzPolicyReaderRole.ps1` will create the role at the scope defined in `global-settings.json`. It will contain:
+Create a custom role to be used by the planing stages' service connections **EPAC Policy Reader role**. Script `./Scripts/Operations/New-AzPolicyReaderRole.ps1` will create the role at the scope defined in `global-settings.json`. It will contain:
    - `Microsoft.Authorization/policyAssignments/read`
    - `Microsoft.Authorization/policyDefinitions/read`
    - `Microsoft.Authorization/policySetDefinitions/read`
@@ -132,7 +132,7 @@ Create Service Principals for the pipeline execution and setup your DevOps envir
   - Owner role at subscription for deploying to your EPAC development subscription
   - Owner role at subscription for deploying to your EPAC test subscription
 - Per Azure tenant at your highest Management Group (called rootScope in EPAC vernacular)
-  - Security Reader and Policy Reader (custom) or Policy Contributor roles for planning the EPAC prod deployment
+  - Security Reader and EPAC Policy Reader (custom) or Policy Contributor roles for planning the EPAC prod deployment
   - Security Reader and Policy Contributor for deploying Policies, Initiatives and Assignments in the EPAC prod environment
   - User Administrator for assigning roles to the Assignments' Managed Identities (for remediation tasks) in the EPAC prod environment
 

--- a/Scripts/Operations/New-AzPolicyReaderRole.ps1
+++ b/Scripts/Operations/New-AzPolicyReaderRole.ps1
@@ -21,12 +21,12 @@ $pacEnvironment = Select-PacEnvironment $PacEnvironmentSelector -definitionsRoot
 Set-AzCloudTenantSubscription -cloud $pacEnvironment.cloud -tenantId $pacEnvironment.tenantId -subscriptionId $pacEnvironment.defaultSubscriptionId -interactive $pacEnvironment.interactive
 
 Write-Information "==================================================================================================="
-Write-Information "Creating custom role 'Policy Reader'"
+Write-Information "Creating custom role 'EPAC Policy Reader'"
 Write-Information "==================================================================================================="
 
 
 $role = [Microsoft.Azure.Commands.Resources.Models.Authorization.PSRoleDefinition]::new()
-$role.Name = 'Policy Reader'
+$role.Name = 'EPAC Policy Reader'
 $role.Id = '2baa1a7c-6807-46af-8b16-5e9d03fba029'
 $role.Description = 'Read access to Azure Policy.'
 $role.IsCustom = $true


### PR DESCRIPTION
Added EPAC Prefix to the role to avoid collisions as Policy Reader can be a common term
Also updated role definition in the ./readme.md file to reflect the roles assigned