### PR TITLE
Documentation: Changing User Administrator to User Access Administrator

### DIFF
--- a/Pipeline/README.md
+++ b/Pipeline/README.md
@@ -67,8 +67,8 @@ Create service connections for each of your environments and require minimum rol
 | sc-pac-plan-2 | prodPlanFeatureStage <br/> prodPlanMainStage |||| EPAC Policy Reader<br/>Security Reader |
 | sc-pac-prod-1 | prodDeployStage-1 ||| Policy Contributor<br/>Security Reader ||
 | sc-pac-prod-2 | prodDeployStage-2 |||| Policy Contributor<br/>Security Reader |
-| sc-pac-roles-1 | prodRolesStage-1 ||| User Administrator<br/>Security Reader ||
-| sc-pac-roles-2 | prodRolesStage-2 |||| User Administrator<br/>Security Reader |
+| sc-pac-roles-1 | prodRolesStage-1 ||| User Access Administrator<br/>Security Reader ||
+| sc-pac-roles-2 | prodRolesStage-2 |||| User Access Administrator<br/>Security Reader |
 | none | prodNoPolicyStage-1 <br/> prodNoRoleStage-1 <br/> prodNoPolicyStage-2 </br> prodNoRoleStage-2 |||||
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Create Service Principals for the pipeline execution and setup your DevOps envir
 - Per Azure tenant at your highest Management Group (called rootScope in EPAC vernacular)
   - Security Reader and EPAC Policy Reader (custom) or Policy Contributor roles for planning the EPAC prod deployment
   - Security Reader and Policy Contributor for deploying Policies, Initiatives and Assignments in the EPAC prod environment
-  - User Administrator for assigning roles to the Assignments' Managed Identities (for remediation tasks) in the EPAC prod environment
+  - User Access Administrator for assigning roles to the Assignments' Managed Identities (for remediation tasks) in the EPAC prod environment
 
 > **Note:** 
 > When creating a Service Connection in Azure DevOps you can set up the service connections on Subscription or a Management Group scope level, when configuring the service connection for the EPAC Developer and Test subscriptions the service connections scope level is **Subscription**, however when creating a Service Connections for EPAC Prod Plan, EPAC Prod Deployment and EPAC Role Assignment the service connection scope level is **Management Group**.


### PR DESCRIPTION
Changed the role name from User Administrator to User Access Administrator to reflect the correct role needed for the Role Assignment Service Principal needed for DevOps Pipeline and to mitigate confusion between the User Administrator Azure AD Role and the User Access Administrator RBAC Role.

Resolves #79