### PR TITLE
Updated hardcoded value to reflect environment variable

### DIFF
--- a/StarterKit/Pipelines/GitHubActions/.github/workflows/build.yaml
+++ b/StarterKit/Pipelines/GitHubActions/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
           }
-          if (Test-Path Output) {
+          if (Test-Path $env:planFolder) {
             echo "Deploy=true" >> $env:GITHUB_ENV
           }
       - shell: pwsh


### PR DESCRIPTION
Currently if someone changes the output folder name, the test-path check fails