### PR TITLE
Pac owner id fix

### DIFF
--- a/Scripts/Deploy/Build-DeploymentPlans.ps1
+++ b/Scripts/Deploy/Build-DeploymentPlans.ps1
@@ -146,7 +146,7 @@ if ($exemptionsAreManaged) {
         -deployedExemptions $deployedPolicyResources.policyExemptions `
         -exemptions $exemptions
 }
-
+$pacOwnerId = $pacEnvironment.pacOwnerId
 $timestamp = Get-Date -AsUTC -Format "u"
 $policyPlan = @{
     createdOn            = $timestamp

--- a/StarterKit/Pipelines/GitHubActions/.github/workflows/build.yaml
+++ b/StarterKit/Pipelines/GitHubActions/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
             gh run cancel ${{ github.run_id }}
             gh run watch ${{ github.run_id }}
           }
-          if (Test-Path Output) {
+          if (Test-Path $env:planFolder) {
             echo "Deploy=true" >> $env:GITHUB_ENV
           }
       - shell: pwsh


### PR DESCRIPTION
The pacOwnerId is null when a deployment plan is generated. This is a problem because if desired state is set to the 'full' strategy, the deployment plan will call for policy deletion since pacOwnerId (null) does not match the pacOwnerId in the policy definition.


<img width="429" alt="Screenshot 2023-04-20 at 12 23 24 PM" src="https://user-images.githubusercontent.com/7807870/233428262-1c3af7ef-c80f-447d-b407-ae7fe6138e7f.png">
