### PR TITLE
Added managementGroups/read to custom role.

### DIFF
--- a/Scripts/Operations/New-AzPolicyReaderRole.ps1
+++ b/Scripts/Operations/New-AzPolicyReaderRole.ps1
@@ -59,7 +59,8 @@ $perms = @(
     "Microsoft.Authorization/policyexemptions/read",
     "Microsoft.Authorization/policysetdefinitions/read",
     "Microsoft.PolicyInsights/*",
-    "Microsoft.Management/register/action"
+    "Microsoft.Management/register/action",
+    "Microsoft.Management/managementGroups/read"
 )
 
 $role.Actions = $perms


### PR DESCRIPTION
Added "Microsoft.Management/managementGroups/read" to the custom role. This is required to verify the service principal with CI/CD platforms. CI/CD platforms cannot verify the management group permissions without read.