### PR TITLE
Update ALZ-Root-Default.jsonc

### DIFF
--- a/Scripts/CloudAdoptionFramework/policyAssignments/ALZ-Root-Default.jsonc
+++ b/Scripts/CloudAdoptionFramework/policyAssignments/ALZ-Root-Default.jsonc
@@ -12,7 +12,7 @@
         "emailSecurityContact": "", // Security contact email address for Microsoft Defender for Cloud
         "ascExportResourceGroupName": "mdfc-export", // Resource group to export Microsoft Defender for Cloud data to
         "ascExportResourceGroupLocation": "", // Location of the resource group to export Microsoft Defender for Cloud data to
-        "dataCollectionRuleResourceId": "" // Resource Id for the DCR for Azure Monitor - see https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/resourceGroupTemplates/dataCollectionRule.json
+        "dcrResourceId": "" // Resource Id for the DCR for Azure Monitor - see https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/resourceGroupTemplates/dataCollectionRule.json
     },
     "children": [
         {
@@ -201,7 +201,7 @@
                         "policySetId": "/providers/Microsoft.Authorization/policySetDefinitions/924bfe3a-762f-40e7-86dd-5c8b95eb09e6",
                     },
                     "parameters": {
-                        "bringYourOwnUserAssignedManagedIdentity": "false"
+                        "bringYourOwnUserAssignedManagedIdentity": false
                     },
                     "nonComplianceMessages": [
                         {
@@ -217,11 +217,11 @@
                         "description": "Enable Azure Monitor for the Virtual Machine Scale Sets in the specified scope (Management group, Subscription or resource group). Takes Log Analytics workspace as parameter. Note: if your scale set upgradePolicy is set to Manual, you need to apply the extension to the all VMs in the set by calling upgrade on them. In CLI this would be az vmss update-instances."
                     },
                     "definitionEntry": {
-                        "policySetId": "/providers/Microsoft.Authorization/policySetDefinitions/f5bf694c-cca7-4033-b883-3a23327d5485",
+                        "policySetId": "/providers/Microsoft.Authorization/policySetDefinitions/f5bf694c-cca7-4033-b883-3a23327d5485"
                         "displayName": "VMSS Monitoring"
                     },
                     "parameters": {
-                        "bringYourOwnUserAssignedManagedIdentity": "false"
+                        "bringYourOwnUserAssignedManagedIdentity": false
                     },
                     "nonComplianceMessages": [
                         {


### PR DESCRIPTION
Data Collection Rule Resource Id should be dcrResourceId according to the initiative definition "Enable Azure Monitor for VMSS with Azure Monitoring Agent(AMA)".

Also, removing quotation marks for the boolean values of "Bring Your Own User-Assigned Managed Identity" as allowed values are false; true and not "false"; "true".