### PR TITLE
Update Set-AzPolicyAssignmentRestMethod.ps1

### DIFF
--- a/Scripts/Helpers/Set-AzPolicyAssignmentRestMethod.ps1
+++ b/Scripts/Helpers/Set-AzPolicyAssignmentRestMethod.ps1
@@ -35,7 +35,7 @@ function Set-AzPolicyAssignmentRestMethod {
         }
     }
     if ($AssignmentObj.identityRequired) {
-        $assignment.location = $AssignmentObj.managedIdentityLocation
+        $assignment.location = $AssignmentObj.managedIdentityLocation | Select-Object -First 1
     }
     if ($parameters.psbase.Count -gt 0) {
         $assignment.properties.parameters = $parameters


### PR DESCRIPTION
managedIdentityLocation is an array and need to be converted as a string so the API would allow the creation of the policy assignment

https://learn.microsoft.com/en-us/rest/api/policy/policy-assignments/create-by-id?view=rest-policy-2023-04-01&tabs=HTTP