### PR TITLE
Adding description when deploying the role assignments

### DIFF
--- a/Scripts/Deploy/Deploy-RolesPlan.ps1
+++ b/Scripts/Deploy/Deploy-RolesPlan.ps1
@@ -151,7 +151,7 @@ else {
                 RoleDefinitionId      = $roleAssignment.roleDefinitionId
                 RoleDisplayName       = $roleAssignment.roleDisplayName
                 AssignmentDisplayName = $assignmentInfo.displayName
-                Description           = "Deployed bu EPAC"
+                Description           = "Deployed by EPAC"
             }
             Set-AzRoleAssignmentRestMethod @splat -IgnoreDuplicateError
         }

--- a/Scripts/Deploy/Deploy-RolesPlan.ps1
+++ b/Scripts/Deploy/Deploy-RolesPlan.ps1
@@ -151,6 +151,7 @@ else {
                 RoleDefinitionId      = $roleAssignment.roleDefinitionId
                 RoleDisplayName       = $roleAssignment.roleDisplayName
                 AssignmentDisplayName = $assignmentInfo.displayName
+                Description           = "Deployed bu EPAC"
             }
             Set-AzRoleAssignmentRestMethod @splat -IgnoreDuplicateError
         }


### PR DESCRIPTION
We are using a similar pipeline for planning RBAC permissions.
It would be nice to filter out all the role assignments that EPAC is deploying.

Description is the only option for now?!