### PR TITLE
Having one chunk should not be presented as an error message, possibly a warning

### DIFF
--- a/Scripts/Helpers/Split-ArrayIntoChunks.ps1
+++ b/Scripts/Helpers/Split-ArrayIntoChunks.ps1
@@ -25,7 +25,7 @@ function Split-ArrayIntoChunks {
         }
         [array] $chunks = [array]::CreateInstance([array], $NumberOfChunks)
         if ($NumberOfChunks -eq 1) {
-            Write-Error "Coding error: NumberOfChunks is 1" -ErrorAction Continue
+            Write-Warning "Coding warning: NumberOfChunks is 1" -WarningAction Continue
             $chunks[0] = $Array
             return , $chunks
         }

--- a/Scripts/Helpers/Split-HashtableIntoChunks.ps1
+++ b/Scripts/Helpers/Split-HashtableIntoChunks.ps1
@@ -25,7 +25,7 @@ function Split-HashtableIntoChunks {
         }
         [array] $chunks = [array]::CreateInstance([array], $NumberOfChunks)
         if ($NumberOfChunks -eq 1) {
-            Write-Error "Coding error: NumberOfChunks is 1" -ErrorAction Continue
+            Write-Warning "Coding warning: NumberOfChunks is 1" -WarningAction Continue
             $chunks[0] = $Table
             return , $chunks
         }


### PR DESCRIPTION
If not using the latest Az version, one might receive the following error message:
"WARNING: INITIALIZATION: Fallback context save mode to process because of error during checking token cache persistence: Persistence check fails due to unknown error.". 

Hence, logic for $throttleLimit should be revised.

In the meantime, setting that variable to 1 leaves the logic for throttling out of the code, but ends up presenting an error message (despite proceeding to succeed). This is not an error but works as expected. Therefore, the Write-Error should either be a Write-Information, a Write-Warning, or nothing at all. I decided to go for Write-Warning as hopefully, there will be a fix to the original problem of throttling while not using the very latest Az version.