### PR TITLE
fix: Correct variable used for outputting exemptions in Output-PolicyExemptions

### DIFF
--- a/Scripts/Helpers/Out-PolicyExemptions.ps1
+++ b/Scripts/Helpers/Out-PolicyExemptions.ps1
@@ -102,7 +102,7 @@ function Out-PolicyExemptions {
     #endregion Transformations
 
     Write-Information ""
-    $selectedExemptions = $policyExemptions.Values
+    $selectedExemptions = $Exemptions.Values
     $numberOfExemptions = $selectedExemptions.Count
     if ($ActiveExemptionsOnly) {
 


### PR DESCRIPTION
I believe this will resolve my issue, it did locally in my environment, in https://github.com/Azure/enterprise-azure-policy-as-code/issues/612 where exemptions aren't outputted to file. 