### PR TITLE
Fix plan artifact path in github workflows

### DIFF
--- a/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-dev-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-dev-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       pacEnvironmentSelector: epac-dev
       planGitHubEnvironment: PAC-DEV
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-epac-dev"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 
@@ -49,7 +49,7 @@ jobs:
     with:
       pacEnvironmentSelector: epac-dev
       planGitHubEnvironment: PAC-DEV
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-epac-dev"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 

--- a/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-tenant-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-tenant-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       pacEnvironmentSelector: tenant
       planGitHubEnvironment: TENANT-DEPLOY-POLICY
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-tenant"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 
@@ -49,6 +49,6 @@ jobs:
     with:
       pacEnvironmentSelector: tenant
       planGitHubEnvironment: TENANT-DEPLOY-ROLES
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-tenant"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit

--- a/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-dev-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-dev-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       pacEnvironmentSelector: epac-dev
       planGitHubEnvironment: PAC-DEV
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-epac-dev"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 
@@ -49,7 +49,7 @@ jobs:
     with:
       pacEnvironmentSelector: epac-dev
       planGitHubEnvironment: PAC-DEV
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-epac-dev"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 

--- a/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-nonprod-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-nonprod-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       pacEnvironmentSelector: nonprod
       planGitHubEnvironment: NONPROD-DEPLOY-POLICY
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-nonprod"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 
@@ -45,6 +45,6 @@ jobs:
     with:
       pacEnvironmentSelector: nonprod
       planGitHubEnvironment: NONPROD-DEPLOY-ROLES
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-nonprod"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit

--- a/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-prod-exemptions-only-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-prod-exemptions-only-workflow.yml
@@ -33,6 +33,6 @@ jobs:
     with:
       pacEnvironmentSelector: prod
       planGitHubEnvironment: PROD-DEPLOY-POLICY
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-prod"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit

--- a/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-prod-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-prod-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       pacEnvironmentSelector: prod
       planGitHubEnvironment: PROD-DEPLOY-POLICY
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-prod"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit
 
@@ -45,6 +45,6 @@ jobs:
     with:
       pacEnvironmentSelector: prod
       planGitHubEnvironment: PROD-DEPLOY-ROLES
-      PAC_INPUT_FOLDER: "$(GITHUB_WORKSPACE)/plans-prod"
+      PAC_INPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
     secrets: inherit

--- a/StarterKit/Pipelines/GitHubActions/templates-ps1-module/deploy-policy.yml
+++ b/StarterKit/Pipelines/GitHubActions/templates-ps1-module/deploy-policy.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: plans-${{ inputs.pacEnvironmentSelector }}
+          path: ${{ inputs.PAC_INPUT_FOLDER }}
 
       - name: Install Required Modules
         uses: Azure/powershell@v2

--- a/StarterKit/Pipelines/GitHubActions/templates-ps1-module/deploy-roles.yml
+++ b/StarterKit/Pipelines/GitHubActions/templates-ps1-module/deploy-roles.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: plans-${{ inputs.pacEnvironmentSelector }}
+          path: ${{ inputs.PAC_INPUT_FOLDER }}
 
       - name: Install Required Modules
         uses: Azure/powershell@v2

--- a/StarterKit/Pipelines/GitHubActions/templates-ps1-use-scripts/deploy-policy.yml
+++ b/StarterKit/Pipelines/GitHubActions/templates-ps1-use-scripts/deploy-policy.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: plans-${{ inputs.pacEnvironmentSelector }}
+          path: ${{ inputs.PAC_INPUT_FOLDER }}
 
       - name: Azure Login
         uses: azure/login@v2

--- a/StarterKit/Pipelines/GitHubActions/templates-ps1-use-scripts/deploy-roles.yml
+++ b/StarterKit/Pipelines/GitHubActions/templates-ps1-use-scripts/deploy-roles.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: plans-${{ inputs.pacEnvironmentSelector }}
+          path: ${{ inputs.PAC_INPUT_FOLDER }}
 
       - name: Azure Login
         uses: azure/login@v2


### PR DESCRIPTION

- Resolves: #655 

Change PAC_INPUT_FOLDER in github workflow yml files
Update reusable github workflow yml templates to download the plan artifact to the same path as the deployjob expects

![epac-input-folder-correct-path](https://github.com/Azure/enterprise-azure-policy-as-code/assets/7443949/3647fe2b-df9f-4aca-8de1-577938a11854)
