### PR TITLE
Fix OnlyCheckManagedAssignments in New-AzRemediationTasks

### DIFF
--- a/Scripts/Helpers/Find-AzNonCompliantResources.ps1
+++ b/Scripts/Helpers/Find-AzNonCompliantResources.ps1
@@ -81,10 +81,10 @@ function Find-AzNonCompliantResources {
                 $assignmentPacOwner = $assignment.pacOwner
                 $process = $false
                 if ($OnlyCheckManagedAssignments -and $assignmentPacOwner -ne "otherPaC" -and $assignmentPacOwner -ne "unknownOwner") {
-                    # owned by the PaC solution of auto-created by Defender for Cloud (DfC)
+                    # owned by the PaC solution or auto-created by Defender for Cloud (DfC)
                     $process = $true
                 }
-                else {
+                elseif (!$OnlyCheckManagedAssignments) {
                     $process = $true
                 }
                 if ($process) {


### PR DESCRIPTION
When running `New-AzRemediationTasks -OnlyCheckManagedAssignments` on a management group that contains policy assignments owned by another pacEnvironment, remediations will be run on the other environments policy assignments as well.

It looks like there was a mistake in the if statement in this file.

Also noticed a mistake in the comment so corrected that as well.

Have tested this locally and resolved the issue I was having.