### PR TITLE
fix null error on $rawMetadata.createdOn

### DIFF
--- a/Scripts/Operations/Export-AzPolicyResources.ps1
+++ b/Scripts/Operations/Export-AzPolicyResources.ps1
@@ -410,11 +410,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = ($rawMetadata.updatedOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = ($rawMetadata.createdOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category
@@ -498,11 +498,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = ($rawMetadata.updatedOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = ($rawMetadata.createdOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category
@@ -623,11 +623,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = ($rawMetadata.updatedOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = ($rawMetadata.createdOn).ToString("s")
+                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category

--- a/Scripts/Operations/Export-AzPolicyResources.ps1
+++ b/Scripts/Operations/Export-AzPolicyResources.ps1
@@ -410,10 +410,14 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
+                $rowObj.lastChange = if ($null -ne $rawMetadata.updatedOn) { ($rawMetadata.updatedOn).ToString("s") } else { "n/a" }
+            }
+            elseif ($null -ne $rawMetadata.createdBy) {
+                $rowObj.principalId = $rawMetadata.createdBy
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
-                $rowObj.principalId = $rawMetadata.createdBy
+                $rowObj.principalId = "n/a"
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
@@ -498,10 +502,14 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
+                $rowObj.lastChange = if ($null -ne $rawMetadata.updatedOn) { ($rawMetadata.updatedOn).ToString("s") } else { "n/a" }
+            }
+            elseif ($null -ne $rawMetadata.createdBy) {
+                $rowObj.principalId = $rawMetadata.createdBy
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
-                $rowObj.principalId = $rawMetadata.createdBy
+                $rowObj.principalId = "n/a"
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
@@ -623,10 +631,14 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
+                $rowObj.lastChange = if ($null -ne $rawMetadata.updatedOn) { ($rawMetadata.updatedOn).ToString("s") } else { "n/a" }
+            }
+            elseif ($null -ne $rawMetadata.createdBy) {
+                $rowObj.principalId = $rawMetadata.createdBy
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
-                $rowObj.principalId = $rawMetadata.createdBy
+                $rowObj.principalId = "n/a"
                 $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {

--- a/Scripts/Operations/Export-AzPolicyResources.ps1
+++ b/Scripts/Operations/Export-AzPolicyResources.ps1
@@ -410,11 +410,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category
@@ -498,11 +498,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category
@@ -623,11 +623,11 @@ foreach ($pacSelector in $globalSettings.pacEnvironmentSelectors) {
             }
             if ($null -ne $rawMetadata.updatedBy) {
                 $rowObj.principalId = $rawMetadata.updatedBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             else {
                 $rowObj.principalId = $rawMetadata.createdBy
-                $rowObj.lastChange = if ($rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
+                $rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
             }
             if ($null -ne $rawMetadata.category) {
                 $rowObj.category = $rawMetadata.category


### PR DESCRIPTION
Exporting the policies raised a bunch of errors around ($rawMetadata.createdOn).ToString("s"). Since I don't like errors I wrote a fix for it.

## Error
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/5ff55c77-7509-46e2-be09-139f5f09e76d">

## File affected
Export-AzPolicyResources.ps1:

## Fix
``` pwsh
$rowObj.lastChange = if ($null -ne $rawMetadata.createdOn) { ($rawMetadata.createdOn).ToString("s") } else { "n/a" }
```
