### PR TITLE
allow nonprod and prod plans if only one of policy or role changes

### DIFF
--- a/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-dev-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/GitHub-Flow/epac-dev-workflow.yml
@@ -56,6 +56,9 @@ jobs:
   tenantPlan:
     name: Plan tenant
     needs: [deployPolicy, deployRoles]
+    if: |
+      always()
+      && !contains(needs.*.result,'failure')        
     uses: ./.github/workflows/plan.yml
     with:
       pacEnvironmentSelector: tenant

--- a/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-dev-workflow.yml
+++ b/StarterKit/Pipelines/GitHubActions/Release-Flow/epac-dev-workflow.yml
@@ -56,9 +56,12 @@ jobs:
   nonprodPlan:
     name: Plan nonprod
     needs: [deployPolicy, deployRoles]
+    if: |
+      always()
+      && !contains(needs.*.result,'failure')    
     uses: ./.github/workflows/plan.yml
     with:
-      pacEnvironmentSelector: nonnprod
+      pacEnvironmentSelector: nonprod
       planGitHubEnvironment: NONPROD-PLAN
       PAC_OUTPUT_FOLDER: ./Output
       PAC_DEFINITIONS_FOLDER: ./Definitions
@@ -67,6 +70,9 @@ jobs:
   prodPlan:
     name: Plan prod
     needs: [deployPolicy, deployRoles]
+    if: |
+      always()
+      && !contains(needs.*.result,'failure')
     uses: ./.github/workflows/plan.yml
     with:
       pacEnvironmentSelector: prod


### PR DESCRIPTION
Fixes a quirk w/ the gihub starterkit workflows that if there is only a change policy or only a change in roles and not the other than the plans for prod and nonprod will not run. 
Type fix to remove extra n from nonnprod