### PR TITLE
Write failedPolicyRemediationTasksJsonString and createWorkItem on Failed to Create Remediation

### DIFF
--- a/Scripts/Operations/New-AzRemediationTasks.ps1
+++ b/Scripts/Operations/New-AzRemediationTasks.ps1
@@ -385,7 +385,6 @@ else {
         if ($failed -gt 0) {
             Write-Information "$failed failed"
         }
-
         if (($failed -gt 0) -or ($failedToCreate -gt 0)) {
             if (-not $Interactive) {
                 $failedPolicyRemediationTasksJsonString = $failedPolicyRemediationTasks | ConvertTo-Json -Depth 10 -Compress

--- a/Scripts/Operations/New-AzRemediationTasks.ps1
+++ b/Scripts/Operations/New-AzRemediationTasks.ps1
@@ -384,6 +384,9 @@ else {
         Write-Information "$succeeded succeeded"
         if ($failed -gt 0) {
             Write-Information "$failed failed"
+        }
+
+        if (($failed -gt 0) -or ($failedToCreate -gt 0)) {
             if (-not $Interactive) {
                 $failedPolicyRemediationTasksJsonString = $failedPolicyRemediationTasks | ConvertTo-Json -Depth 10 -Compress
                 Write-Output "##vso[task.setvariable variable=failedPolicyRemediationTasksJsonString;isOutput=true]$($failedPolicyRemediationTasksJsonString)"

--- a/Scripts/Operations/New-AzRemediationTasks.ps1
+++ b/Scripts/Operations/New-AzRemediationTasks.ps1
@@ -385,13 +385,6 @@ else {
         if ($failed -gt 0) {
             Write-Information "$failed failed"
         }
-        if (($failed -gt 0) -or ($failedToCreate -gt 0)) {
-            if (-not $Interactive) {
-                $failedPolicyRemediationTasksJsonString = $failedPolicyRemediationTasks | ConvertTo-Json -Depth 10 -Compress
-                Write-Output "##vso[task.setvariable variable=failedPolicyRemediationTasksJsonString;isOutput=true]$($failedPolicyRemediationTasksJsonString)"
-                $createWorkItem = $true
-            }
-        }
         if ($canceled -gt 0) {
             Write-Information "$canceled canceled"
         }
@@ -399,6 +392,12 @@ else {
             Write-Information "$stillRunning still running after $checkForMinutes minutes"
         }
         if (-not $Interactive) {
+            if (($failed -gt 0) -or ($failedToCreate -gt 0)) {
+                $failedPolicyRemediationTasksJsonString = $failedPolicyRemediationTasks | ConvertTo-Json -Depth 10 -Compress
+                Write-Output "##vso[task.setvariable variable=failedPolicyRemediationTasksJsonString;isOutput=true]$($failedPolicyRemediationTasksJsonString)"
+                $createWorkItem = $true
+            } 
+              
             Write-Output "##vso[task.setvariable variable=createWorkItem;isOutput=true]$($createWorkItem)"
         }
     }


### PR DESCRIPTION
I ran into a situation where the number of `$failed` remediation tasks was `0`. But the `$failedToCreate` was `> 0`. WIth the current script, the property `createWorkItem` will **not** be set to `True` and the `failedPolicyRemediationTasksJsonString` property remains empty.

Since the tasks that are "failed to be created" are already being added to the `$failedPolicyRemediationTasks`, this fix allows for that information to be processed properly.

I modified as little as possible in the existing script to gain functionality.


