### PR TITLE
Update Get-AzResourceListRestMethod.ps1 to update function exec-azres…

### DIFF
--- a/Scripts/Helpers/RestMethods/Get-AzResourceListRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Get-AzResourceListRestMethod.ps1
@@ -5,7 +5,7 @@ function Get-AzResourceListRestMethod {
         $SubscriptionId
     )
     
-    function Exec-AzRestMethod {
+    function Invoke-AzRestMethodCustom {
         [CmdletBinding()]
         param (
             [Parameter(Mandatory = $true)]
@@ -39,14 +39,14 @@ function Get-AzResourceListRestMethod {
     # Get the basic resources    
     $ApiVersion = "2021-04-01"
     $path = "/subscriptions/$SubscriptionId/resources?api-version=$ApiVersion"
-    $resources = Exec-AzRestMethod -path $path -method GET
+    $resources = Invoke-AzRestMethodCustom -path $path -method GET
 
     # Get the Subnets for all the Vnets found in the basic resources
     $snets = $($resources.value | Where-Object { $_.type -eq 'Microsoft.Network/virtualNetworks' })
     foreach ($snet in $snets) {   
         $ApiVersion = "2024-01-01"
         $path = "$($snet.id)/subnets?api-version=$ApiVersion"
-        $subnetResources = Exec-AzRestMethod -path $path -method GET
+        $subnetResources = Invoke-AzRestMethodCustom -path $path -method GET
         $resources.value += $subnetResources.value
     }
 


### PR DESCRIPTION
…tmethod

While using this fuction in our organization ,facing linting issues shared below. tried by tweak function name by Invoke-AzRestMethodCustom  instead Exec-AzRestMethod and linting got passed. Could you please take a look on this code and suggest.

powershell latest version also not being used in code. it seems exec-azrestmethod is not being used by powershell latest version https://learn.microsoft.com/en-us/powershell/module/az.accounts/invoke-azrestmethod?view=azps-13.0.0


Linted [POWERSHELL] files with [powershell]: Found 1 error(s) - (191.84s) (expand for details)
  - Using [powershell v7.4.1] https://megalinter.io/7.10.0/descriptors/powershell_powershell
  - MegaLinter key: [POWERSHELL_POWERSHELL]
  - Rules config: [/github/workspace/.github/linters/.powershell-psscriptanalyzer.psd1]
  - Number of files analyzed: [172] [powershell] Scripts/Helpers/RestMethods/Get-AzResourceListRestMethod.ps1 - ERROR - 1 error(s) --Error detail:
  
  Severity RuleName           ScriptName                       Line Message
  -------- --------           ----------                       ---- -------
   Warning PSUseApprovedVerbs Get-AzResourceListRestMethod.ps1    8 The cmdlet 'Ex
                                                                    ec-AzRestMetho
                                                                    d' uses an una
                                                                    pproved verb.
  


there were some trail spaces issues also in this file , please update those also ,I have fixed those trail spaces at my end