### PR TITLE
Adjust ProgressIncrement when called as type PolicySetDefinition

### DIFF
--- a/Scripts/Helpers/Get-AzPolicyOrSetDefinitions.ps1
+++ b/Scripts/Helpers/Get-AzPolicyOrSetDefinitions.ps1
@@ -21,6 +21,7 @@ function Get-AzPolicyOrSetDefinitions {
     $query = $null
     $progressItemName = $null
     $excludedIds = $null
+    $progressIncrement = 1000
     switch ($DefinitionType) {
         policyDefinitions {
             $query = "PolicyResources | where type == 'microsoft.authorization/policydefinitions'"
@@ -31,10 +32,11 @@ function Get-AzPolicyOrSetDefinitions {
             $query = "PolicyResources | where type == 'microsoft.authorization/policysetdefinitions'"
             $progressItemName = "Policy Set definitions"
             $excludedIds = $desiredState.excludedPolicySetDefinitions
+            $progressIncrement = 250
         }
     }
 
-    $policyResources = Search-AzGraphAllItems -Query $query -ProgressItemName $progressItemName
+    $policyResources = Search-AzGraphAllItems -Query $query -ProgressItemName $progressItemName -ProgressIncrement $progressIncrement
     foreach ($policyResource in $policyResources) {
         $resourceTenantId = $policyResource.tenantId
         if ($resourceTenantId -in @($null, "", $environmentTenantId)) {

--- a/Scripts/Helpers/Search-AzGraphAllItems.ps1
+++ b/Scripts/Helpers/Search-AzGraphAllItems.ps1
@@ -9,10 +9,10 @@ function Search-AzGraphAllItems {
     # Search-AzGraph can only return a maximum of 1000 items. Without the -First it will only return 100 items
     $body = @{
         query = $Query
-        # options = @{
-        #     "`$top"  = 1000
-        #     "`$skip" = 0
-        # }
+        options = @{
+            "`$top"  = $ProgressIncrement
+            "`$skip" = 0
+        }
     }
     if ($ScopeSplat.ManagementGroup) {
         $body.managementGroups = @($ScopeSplat.ManagementGroup)


### PR DESCRIPTION
It seems like the ResourceGraph limits is reached when calling the PolicySetDefinition with the default limit of 1000.

To remediate this issue, we can adjust the value to 250 and doesn't affect the performance.
We had similar output as the issue in #863 .