### PR TITLE
addresses issue #875 to trigger when the tag is absent or required

### DIFF
--- a/StarterKit/Definitions-Common/policyDefinitions/Tagging/resources-required-tag-dynamic-notscope.jsonc
+++ b/StarterKit/Definitions-Common/policyDefinitions/Tagging/resources-required-tag-dynamic-notscope.jsonc
@@ -108,7 +108,7 @@
                     },
                     {
                         "field": "[concat('tags[', parameters('tagName'), ']')]",
-                        "exists": "true"
+                        "exists": "false"
                     },
                     {
                         "count": {

--- a/StarterKit/Definitions-Common/policyDefinitions/Tagging/rg-required-tag-dynamic-notscope.json
+++ b/StarterKit/Definitions-Common/policyDefinitions/Tagging/rg-required-tag-dynamic-notscope.json
@@ -57,7 +57,7 @@
                     },
                     {
                         "field": "[concat('tags[', parameters('tagName'), ']')]",
-                        "exists": "true"
+                        "exists": "false"
                     },
                     {
                         "count": {


### PR DESCRIPTION
If the intent is to flag or block resources that are missing the tag, you would typically set "exists": "false" so the policy triggers when the tag is absent. Using "exists": "true" will instead trigger the effect when the tag is present, which is the opposite of most “require tag” scenarios.