### PR TITLE
Correct passing a tag to the `Sync-ALZPolicies.ps1` script

### DIFF
--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicies.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicies.ps1
@@ -5,7 +5,7 @@ Param(
     [string] $DefinitionsRootFolder,
 
     [Parameter(Mandatory = $false)]
-    [ValidateScript({ ($_ -eq 'latest') -or ($_.StartsWith("tag/")) }, ErrorMessage = "Allowed values are 'latest' and 'tag/TAG_NAME'")]
+    [ValidateScript({ ($_ -eq 'latest') -or ($_.StartsWith("tags/")) }, ErrorMessage = "Allowed values are 'latest' and 'tags/TAG_NAME'")]
     [string] $GithubRelease = 'latest',
 
     [Parameter(Mandatory = $false)]


### PR DESCRIPTION
The GitHub API needs the path to be `tags` and not `tag`. https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name.

Currently, if one runs `Sync-ALZPolicies.ps1 -GithubRelease tag/2024-10-09` the command fails with a 404 error when calling the GitHub API as `tag` is incorrect for the path.