### PR TITLE
Adding the policy definition version to the reconstructed policy definition object and check for the version element in 4 places.

### DIFF
--- a/Scripts/Helpers/Build-PolicyPlan.ps1
+++ b/Scripts/Helpers/Build-PolicyPlan.ps1
@@ -49,12 +49,13 @@ function Build-PolicyPlan {
 
         $definitionProperties = Get-PolicyResourceProperties -PolicyResource $definitionObject
         $name = $definitionObject.name
-            
+
         $id = "$deploymentRootScope/providers/Microsoft.Authorization/policyDefinitions/$name"
         $displayName = $definitionProperties.displayName
         $description = $definitionProperties.description
         $metadata = Get-DeepCloneAsOrderedHashtable $definitionProperties.metadata
         $mode = $definitionProperties.mode
+        $version = $definitionProperties.version
         $parameters = $definitionProperties.parameters
         $policyRule = $definitionProperties.policyRule
         if ($null -ne $metadata) {
@@ -114,6 +115,7 @@ function Build-PolicyPlan {
             displayName = $displayName
             description = $description
             mode        = $mode
+            version     = $version
             metadata    = $metadata
             parameters  = $parameters
             policyRule  = $policyRule
@@ -193,7 +195,7 @@ function Build-PolicyPlan {
             Write-Information "New '$($displayName)'"
         }
     }
-       
+
 
     $strategy = $PacEnvironment.desiredState.strategy
     foreach ($id in $deleteCandidates.Keys) {

--- a/Scripts/Helpers/Build-PolicySetPlan.ps1
+++ b/Scripts/Helpers/Build-PolicySetPlan.ps1
@@ -49,6 +49,7 @@ function Build-PolicySetPlan {
         $displayName = $definitionProperties.displayName
         $description = $definitionProperties.description
         $metadata = Get-DeepCloneAsOrderedHashtable $definitionProperties.metadata
+        $version = $definitionProperties.version
         $parameters = $definitionProperties.parameters
         $policyDefinitions = $definitionProperties.policyDefinitions
         $policyDefinitionGroups = $definitionProperties.policyDefinitionGroups
@@ -182,6 +183,7 @@ function Build-PolicySetPlan {
             displayName            = $displayName
             description            = $description
             metadata               = $metadata
+            version                = $version
             parameters             = $parameters
             policyDefinitions      = $policyDefinitionsFinal
             policyDefinitionGroups = $policyDefinitionGroupsFinal

--- a/Scripts/Helpers/Confirm-PolicyDefinitionsInPolicySetMatch.ps1
+++ b/Scripts/Helpers/Confirm-PolicyDefinitionsInPolicySetMatch.ps1
@@ -42,7 +42,7 @@ function Confirm-PolicyDefinitionsInPolicySetMatch {
             if ($null -ne $item2.definitionVersion) {
                 # ignore auto-generated definitionVersion, only compare if Policy definition entry has a definitionVersion
                 if ($null -eq $Definitions[$item1.policyDefinitionId].properties) {
-                    # The properties object does not exist, it probably has been splatted
+                    # The properties object does not exist, it probably has been reconstructed for splatting
                     $deployedPolicyDefinitionVersion = $Definitions[$item1.policyDefinitionId].version
                     if ($null -eq $deployedPolicyDefinitionVersion) {
                         # If the version is not found it could be in metadata.version


### PR DESCRIPTION
The Build Deployment Plan will fail if you want to deploy a definition set that is using a custom policy definition with a version element directly in the properties element.

In the function Build-PolicyPlan, every custom policy definition is being re-constructed ( Constructing Policy Set parameters for splatting ) but the version is not being added to the new construction.

This action will have its negative effect in the Build-PolicySetPlan fuction where the version can't be found. The function Confirm-PolicyDefinitionInPolicySetMatch looks for the properties.version element of metadata.version element.

Only if the version exist in the metadata element the plan will be build. But if the custom policy has the version (Azure Policy Standard) directly under the properties element the build will fail.

In this PR 
- the version element will be added to the reconstructed policyDefinition 
- and the Confirm-PolicyDefinitionInPolicySetMatch fuction will check for the existents of the version element 1 4 places instead of 2 (version, metadata.version, properties.version or properties.metadata.version). 

All the official ellements should exist in the reconstructed policyDefintion object
https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-basics

- displayName
- description
- mode
- version
- metadata
- parameters
- policyRule