### PR TITLE
Feature/version

### DIFF
--- a/Scripts/Helpers/Build-PolicyPlan.ps1
+++ b/Scripts/Helpers/Build-PolicyPlan.ps1
@@ -49,12 +49,13 @@ function Build-PolicyPlan {
 
         $definitionProperties = Get-PolicyResourceProperties -PolicyResource $definitionObject
         $name = $definitionObject.name
-            
+
         $id = "$deploymentRootScope/providers/Microsoft.Authorization/policyDefinitions/$name"
         $displayName = $definitionProperties.displayName
         $description = $definitionProperties.description
         $metadata = Get-DeepCloneAsOrderedHashtable $definitionProperties.metadata
         $mode = $definitionProperties.mode
+        $version = $definitionProperties.version
         $parameters = $definitionProperties.parameters
         $policyRule = $definitionProperties.policyRule
         if ($null -ne $metadata) {
@@ -114,6 +115,7 @@ function Build-PolicyPlan {
             displayName = $displayName
             description = $description
             mode        = $mode
+            version     = $version
             metadata    = $metadata
             parameters  = $parameters
             policyRule  = $policyRule
@@ -193,7 +195,7 @@ function Build-PolicyPlan {
             Write-Information "New '$($displayName)'"
         }
     }
-       
+
 
     $strategy = $PacEnvironment.desiredState.strategy
     foreach ($id in $deleteCandidates.Keys) {

--- a/Scripts/Helpers/Build-PolicySetPlan.ps1
+++ b/Scripts/Helpers/Build-PolicySetPlan.ps1
@@ -49,6 +49,7 @@ function Build-PolicySetPlan {
         $displayName = $definitionProperties.displayName
         $description = $definitionProperties.description
         $metadata = Get-DeepCloneAsOrderedHashtable $definitionProperties.metadata
+        $version = $definitionProperties.version
         $parameters = $definitionProperties.parameters
         $policyDefinitions = $definitionProperties.policyDefinitions
         $policyDefinitionGroups = $definitionProperties.policyDefinitionGroups
@@ -182,6 +183,7 @@ function Build-PolicySetPlan {
             displayName            = $displayName
             description            = $description
             metadata               = $metadata
+            version                = $version
             parameters             = $parameters
             policyDefinitions      = $policyDefinitionsFinal
             policyDefinitionGroups = $policyDefinitionGroupsFinal

--- a/Scripts/Helpers/Confirm-PolicyDefinitionsInPolicySetMatch.ps1
+++ b/Scripts/Helpers/Confirm-PolicyDefinitionsInPolicySetMatch.ps1
@@ -42,7 +42,7 @@ function Confirm-PolicyDefinitionsInPolicySetMatch {
             if ($null -ne $item2.definitionVersion) {
                 # ignore auto-generated definitionVersion, only compare if Policy definition entry has a definitionVersion
                 if ($null -eq $Definitions[$item1.policyDefinitionId].properties) {
-                    # The properties object does not exist, it probably has been splatted
+                    # The properties object does not exist, it probably has been reconstructed for splatting
                     $deployedPolicyDefinitionVersion = $Definitions[$item1.policyDefinitionId].version
                     if ($null -eq $deployedPolicyDefinitionVersion) {
                         # If the version is not found it could be in metadata.version


### PR DESCRIPTION
compare local (json) policy set with deployed (Azure) policy set. If local (json) policy set hasn't have a definitionVersion for the referencing policy the latest version of the referencing policy definition will be used to compare it with the deployed (Azure) definitionVersion in the policy set.