### PR TITLE
🐛 Fix Build-PolicyDocumentation script publishing environmentCategories to ADO Wiki

### DIFF
--- a/Scripts/Operations/Build-PolicyDocumentation.ps1
+++ b/Scripts/Operations/Build-PolicyDocumentation.ps1
@@ -326,7 +326,8 @@ foreach ($file in $files) {
                     -DocumentationSpecification $documentationSpecification `
                     -AssignmentsByEnvironment $assignmentsByEnvironment `
                     -IncludeManualPolicies:$IncludeManualPolicies `
-                    -PacEnvironments $pacEnvironments
+                    -PacEnvironments $pacEnvironments `
+                    -WikiClonePat $WikiClonePat
                 # Out-DocumentationForPolicyAssignments `
                 #     -OutputPath $outputPath `
                 #     -WindowsNewLineCells:$true `


### PR DESCRIPTION
Added the -WikiClonePat parameter to the command as it was missing