### PR TITLE
Fix error handling in Remove-AzRoleAssignmentRestMethod to provide warnings for scope locked errors

### DIFF
--- a/Scripts/Helpers/RestMethods/Remove-AzRoleAssignmentRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Remove-AzRoleAssignmentRestMethod.ps1
@@ -16,6 +16,11 @@ function Remove-AzRoleAssignmentRestMethod {
     $statusCode = $response.StatusCode
     if ($statusCode -lt 200 -or $statusCode -ge 300) {
         $content = $response.Content
-        Write-Error "Role assignment deletion failed with error $($statusCode) -- $($content)" -ErrorAction Stop
+        if ($content.Contains("ScopeLocked", [StringComparison]::InvariantCultureIgnoreCase)) {
+            Write-Warning "Ignoring scope locked error: $($statusCode) -- $($content)"
+        }
+        else {
+            Write-Error "Role assignment deletion failed with error $($statusCode) -- $($content)" -ErrorAction Stop
+        }
     }
 }


### PR DESCRIPTION
currently, If Scope has delete lock, the script fail to delete the role assignment and stop processing remaining items.

this fix will write a warning and continue processing other role assignments if `content` contains "ScopeLocked"