### PR TITLE
fix converto-hashtable

### DIFF
--- a/Scripts/Helpers/ConvertTo-HashTable.ps1
+++ b/Scripts/Helpers/ConvertTo-HashTable.ps1
@@ -6,7 +6,7 @@ function ConvertTo-HashTable {
         $InputObject = $null
     )
 
-    [hashtable] $hashTable = [ordered]@{}
+    $hashTable = [ordered]@{}
     if ($null -ne $InputObject) {
         if ($InputObject -is [System.Collections.IDictionary]) {
             if ($InputObject -is [hashtable]) {


### PR DESCRIPTION
was trying to figure out why some more fields were coming in out of order after being converted to a hash table and discovered that the attempt to create an ordered hash table was unsuccessful in the code. 

[hashtable] $hashTable = [ordered]@{} still effectively creates a standard unordered hashtable

while

$hashTable = [ordered]@{} correctly creates an ordered hashtable (which is the labeled as an ordered dictionary type in powershell)