### PR TITLE
Fixes parsing of resourceSelectors in CSV-based exemption files

### DIFF
--- a/Docs/policy-exemptions.md
+++ b/Docs/policy-exemptions.md
@@ -50,8 +50,8 @@ Each exemption must define the following properties:
 - Optional
   - `expiresOn` - empty or expiry date.
   - `assignmentScopeValidation` - `Default` or `DoNotValidate`
-  - `resourceSelectors` - valid JSON (see JSON format below)
-  - `metadata` - valid JSON (see JSON format below)
+  - `resourceSelectors` - valid JSON array (see JSON format [here](./policy-assignments.md#defining-resourceselectors))
+  - `metadata` - valid JSON object (see JSON format below)
 
 ### Metadata
 
@@ -331,8 +331,8 @@ The columns must have the headers as described below. The order of the columns i
   - `expiresOn` - empty or expiry date.
   - `policyDefinitionReferenceIds` - list of ampersand `&` separated [strings as defined above](#specifying-policydefinitionreferenceids).
   - `assignmentScopeValidation` - `Default` or `DoNotValidate`
-  - `resourceSelectors` - valid JSON (see JSON format below)
-  - `metadata` - valid JSON (see JSON format below)
+  - `resourceSelectors` - valid JSON array (see JSON format [here](./policy-assignments.md#defining-resourceselectors))
+  - `metadata` - valid JSON object (see JSON format below)
 
 > [!CAUTION]
 > Breaking change: v10.1.0 replaced the usual comma in `policyDefinitionReferenceIds` with an ampersand `&` to avoid conflicts with the scope Ids. You must replace in-cell commas with ampersands.

--- a/Scripts/Helpers/Build-ExemptionsPlan.ps1
+++ b/Scripts/Helpers/Build-ExemptionsPlan.ps1
@@ -206,8 +206,8 @@ function Build-ExemptionsPlan {
                     $resourceSelectors = $null
                     $step1 = $row.resourceSelectors
                     if (-not [string]::IsNullOrWhiteSpace($step1)) {
-                        $step2 = $step1.Trim()      
-                        if ($step2.StartsWith("{")) {
+                        $step2 = $step1.Trim()
+                        if ($step2.StartsWith("[")) {
                             try {
                                 $step3 = ConvertFrom-Json $step2 -AsHashTable -Depth 100 -NoEnumerate
                             }


### PR DESCRIPTION
`resourceSelectors` provided in the .csv exemptions file is currently being ignored and returned as `null` in the plan, since the build script expected a JSON object (starting with `{`), instead of a JSON array which it is supposed to be. This fix allows valid JSON arrays to be correctly parsed and included in the build, matching the behavior in the [JSON-based exemptions](https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Schemas/policy-exemption-schema.json#L49-L51).

Now when specifying a valid `resourceSelectors` in the CSV file, this is correctly added to the exemption plan:
```jsonc
{
  "/providers/Microsoft.Management/managementGroups/test/providers/Microsoft.Authorization/policyExemptions/Allowed Locations": {
    "id": "/providers/Microsoft.Management/managementGroups/test/providers/Microsoft.Authorization/policyExemptions/Allowed Locations",
    "name": "Exempt from Allowed Locations",
    "displayName": "Exempt from Allowed Locations",
    "description": "Allow some other locations than the default policy",
    "exemptionCategory": "Mitigated",
    "expiresOn": null,
    "scope": "/providers/Microsoft.Management/managementGroups/test",
    "policyAssignmentId": "/providers/Microsoft.Management/managementGroups/test/providers/Microsoft.Authorization/policyAssignments/Allowed-Locations",
    "assignmentScopeValidation": "Default",
    "policyDefinitionReferenceIds": [],
    "resourceSelectors": [
      {
        "name": "activityAlertsNorthEurope",
        "selectors": [
          {
            "kind": "resourceType",
            "in": [
              "microsoft.insights/activityLogAlerts"
            ]
          },
          {
            "kind": "resourceLocation",
            "in": [
              "northeurope"
            ]
          }
        ]
      }
    ],
    "metadata": {
      // ...
    },
    "expired": false,
    "scopeIsValid": true
  }
}
```