### PR TITLE
Fixes duplicates keys in exemption schema

### DIFF
--- a/Schemas/policy-exemption-schema.json
+++ b/Schemas/policy-exemption-schema.json
@@ -57,45 +57,51 @@
                     }
                 },
                 "additionalProperties": false,
-                "oneOf": [
+                "allOf": [
                     {
-                        "required": [
-                            "policyAssignmentId"
+                        "oneOf": [
+                            {
+                                "required": [
+                                    "policyAssignmentId"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "policyDefinitionId"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "policyDefinitionName"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "policySetDefinitionId"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "policySetDefinitionName"
+                                ]
+                            }
                         ]
                     },
                     {
-                        "required": [
-                            "policyDefinitionId"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "policyDefinitionName"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "policySetDefinitionId"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "policySetDefinitionName"
+                        "oneOf": [
+                            {
+                                "required": [
+                                    "scope"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "scopes"
+                                ]
+                            }
                         ]
                     }
                 ],
-				"oneOf": [
-					{
-                        "required": [
-                            "scope"
-                        ]
-                    },
-                    {
-                        "required": [
-                            "scopes"
-                        ]
-                    }
-				],
                 "required": [
                     "name",
                     "displayName",


### PR DESCRIPTION
Duplicates keys should be avoided. 
A strict parser like PowerShell Test-Json fails to parse the current schema. 