### PR TITLE
Handle new Defender managed assignments

### DIFF
--- a/Scripts/Helpers/Confirm-PacOwner.ps1
+++ b/Scripts/Helpers/Confirm-PacOwner.ps1
@@ -33,7 +33,7 @@ function Confirm-PacOwner {
                         return "managedByDfcSecurityPolicies"
                     }
                     elseif ($description.StartsWith("This policy assignment was automatically created by ") -or 
-                        $description -eq "This initiative enables Defender for SQL on SQL VMs and Arc-enabled SQL Servers."
+                        $description.StartsWith("This initiative enables Defender ")
                     ) {
                         $ManagedByCounters.dfcDefenderPlans += 1
                         return "managedByDfcDefenderPlans"

--- a/Scripts/Helpers/Confirm-PacOwner.ps1
+++ b/Scripts/Helpers/Confirm-PacOwner.ps1
@@ -32,7 +32,9 @@ function Confirm-PacOwner {
                         $ManagedByCounters.dfcSecurityPolicies += 1
                         return "managedByDfcSecurityPolicies"
                     }
-                    elseif ($description.StartsWith("This policy assignment was automatically created by ")) {
+                    elseif ($description.StartsWith("This policy assignment was automatically created by ") -or 
+                        $description -eq "This initiative enables Defender for SQL on SQL VMs and Arc-enabled SQL Servers."
+                    ) {
                         $ManagedByCounters.dfcDefenderPlans += 1
                         return "managedByDfcDefenderPlans"
                     }


### PR DESCRIPTION
Adding a new case to skip Defender Plan Managed policies.
Azure Defender for Cloud is creating new assignments for "Defender for SQL servers on Machines provisioning" that do not follow the expected description naming convention "This policy assignment was automatically created by"... so EPAC is trying to delete them.