### PR TITLE
fix:wrong double slash for referencePath format

### DIFF
--- a/Docs/policy-assignments-csv-parameters.md
+++ b/Docs/policy-assignments-csv-parameters.md
@@ -25,7 +25,7 @@ In the example header below the infrastructure environments prod, test, dev, and
 The CSV file generated contains the following headers/columns:
 
 * `name` is the name of the policyDefinition referenced by the Policy Sets being assigned.
-* `referencePath` is only used if the Policy is used more than once in at least one of the Policy Sets to disambiguate them. The format is `<policySetName>//<policyDefinitionReferenceId>`.
+* `referencePath` is only used if the Policy is used more than once in at least one of the Policy Sets to disambiguate them. The format is `<policySetName>\\<policyDefinitionReferenceId>`.
 * `policyType`,`category`,`displayName`,`description`,`groupNames`,`policySets`,`allowedEffects` are optional and not used for deployment planning. They assist you in filling out the `<env>Effect` columns. The CSV file is sorted alphabetically by `category` and `displayName`.
 * `<env>Effect` columns must contain one of the allowedValues or allowedOverrides values. You define which scopes define each type of environment and what short name you give the environment type to use as a column prefix.
 * `<env>Parameters` can contain additional parameters. You can also specify such parameters in JSON. EPAC will use the union of all parameters.


### PR DESCRIPTION
referencePath format in this documentation should be changed from Slash to Backslash. 

Reference:

[operational-scripts-documenting-policy.md](https://github.com/Azure/enterprise-azure-policy-as-code/blob/97093b0d97b646ed6461c1b1cdfe38ce84c1c385/Docs/operational-scripts-documenting-policy.md)

Source code:
https://github.com/Azure/enterprise-azure-policy-as-code/blob/97093b0d97b646ed6461c1b1cdfe38ce84c1c385/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1#L286