### PR TITLE
Allow guardrail policy parameters to be changed from the policy_default_structure definition file

### DIFF
--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -285,6 +285,13 @@ try {
                         enforcementMode = $structureFile.enforcementMode
                     }
 
+                    foreach ($key in $structureFile.defaultParameterValues.psObject.Properties.Name) {
+                        if ($structureFile.defaultParameterValues.$key.policy_assignment_name -eq ($fileContent.name -replace "Guardrails", "GR")) {
+                            $keyName = $structureFile.defaultParameterValues.$key.parameters.parameter_name
+                            $baseTemplate.parameters.Add($keyName, $structureFile.defaultParameterValues.$key.parameters.value)
+                        }
+                    }
+
                     $scope = [ordered]@{
                         $PacEnvironmentSelector = @(
                             $deployment.scope


### PR DESCRIPTION
This commit allows for defining parameters to override the default behavior of ALZ guardrail policies from the alz.policy_default_structure.epac-dev.jsonc file. Previously this was only possible for non-guardrail policies.