### PR TITLE
Update the tag parameter in `Sync-ALZPolicyFromLibrary` & `New-ALZPolicyDefaultStructure`

### DIFF
--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -4,11 +4,12 @@ Param(
     [string] $DefinitionsRootFolder,
 
     [ValidateSet('ALZ', 'FSI', 'AMBA', 'SLZ')]
-    [string]$Type = 'ALZ',
+    [string] $Type = 'ALZ',
 
-    [string]$LibraryPath,
+    [string] $LibraryPath,
 
-    [string]$Tag,
+    [ValidateScript({ "refs/tags/$_" -in (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref }, ErrorMessage = "Tag must be a valid tag." )]
+    [string] $Tag,
 
     [string] $PacEnvironmentSelector
 )
@@ -28,31 +29,28 @@ if ($DefinitionsRootFolder -eq "") {
 }
 
 # Latest tag values
-
-switch ($Type) {
-    'ALZ' {
-        $Tag = "platform/alz/2025.02.0"
-    }
-    'FSI' {
-        $Tag = "platform/fsi/2025.03.0"
-    }
-    'AMBA' {
-        $Tag = "platform/amba/2025.05.0"
-    }
-    'SLZ' {
-        $Tag = "platform/slz/2025.03.0"
+if ($Tag -eq "") {
+    switch ($Type) {
+        'ALZ' {
+            $Tag = "platform/alz/2025.02.0"
+        }
+        'FSI' {
+            $Tag = "platform/fsi/2025.03.0"
+        }
+        'AMBA' {
+            $Tag = "platform/amba/2025.05.0"
+        }
+        'SLZ' {
+            $Tag = "platform/slz/2025.03.0"
+        }
     }
 }
 
 if ($LibraryPath -eq "") {
     $LibraryPath = Join-Path -Path (Get-Location) -ChildPath "temp"
-    if ($Tag) {
-        git clone --config advice.detachedHead=false --depth 1 --branch $Tag https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
-    }
-    else {
-        git clone --depth 1 https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
-    }
 }
+
+git clone --config advice.detachedHead=false --depth 1 --branch $Tag https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
 
 $jsonOutput = [ordered]@{
     managementGroupNameMappings = @{}

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -1,45 +1,44 @@
 Param(
-   
     [Parameter(Mandatory = $true)]
     [string] $DefinitionsRootFolder,
 
     [ValidateSet("ALZ", "AMBA")]
-    [string]$Type = "ALZ",
+    [string] $Type = "ALZ",
  
     [Parameter(Mandatory = $true)]
-    [string]$PacEnvironmentSelector,
+    [string] $PacEnvironmentSelector,
 
-    [string]$LibraryPath,
+    [string] $LibraryPath,
 
-    [switch]$CreateGuardrailAssignments
+    [ValidateScript({ "refs/tags/$_" -in (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref }, ErrorMessage = "Tag must be a valid tag." )]
+    [string] $Tag,
+    
+    [switch] $CreateGuardrailAssignments
 )
 
 # Latest tag values
-
-switch ($Type) {
-    'ALZ' {
-        $Tag = "platform/alz/2025.02.0"
-    }
-    'FSI' {
-        $Tag = "platform/fsi/2025.03.0"
-    }
-    'AMBA' {
-        $Tag = "platform/amba/2025.05.0"
-    }
-    'SLZ' {
-        $Tag = "platform/slz/2025.03.0"
-    }
+if ($Tag -eq "") {
+   switch ($Type) {
+       'ALZ' {
+           $Tag = "platform/alz/2025.02.0"
+       }
+       'FSI' {
+           $Tag = "platform/fsi/2025.03.0"
+       }
+       'AMBA' {
+           $Tag = "platform/amba/2025.05.0"
+       }
+       'SLZ' {
+           $Tag = "platform/slz/2025.03.0"
+       }
+   }
 }
 
 if ($LibraryPath -eq "") {
     $LibraryPath = Join-Path -Path (Get-Location) -ChildPath "temp"
-    if ($Tag) {
-        git clone --config advice.detachedHead=false --depth 1 --branch $Tag https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
-    }
-    else {
-        git clone --depth 1 https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
-    }
 }
+
+git clone --config advice.detachedHead=false --depth 1 --branch $Tag https://github.com/Azure/Azure-Landing-Zones-Library.git $LibraryPath
 
 if ($DefinitionsRootFolder -eq "") {
     if ($null -eq $env:PAC_DEFINITIONS_FOLDER) {


### PR DESCRIPTION
# This PR does
- Implement the `-Tag` parameter with validation in both `Sync-ALZPolicyFromLibrary` & `New-ALZPolicyDefaultStructure`
- Only enter the switch-statement with the latest tags if the `-Tag` param is left empty
- Remove the `if ($Tag)` statement since it alwasy will be true
- Add a space between parameter type and name



# Current problems
## Problem 1

According to the docs the cmdlet `Sync-ALZPolicyFromLibrary` should have `-Tag` as a parameter:
https://github.com/Azure/enterprise-azure-policy-as-code/blob/0181bbf7cc772453b065dc5a45c5cdf486fa7e78/Docs/integrating-with-alz-library.md?plain=1#L79-L80

however it is not implemented, resulting in en error when used:
```powershell
Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type ALZ -Tag "platform/alz/2025.02.0" -PacEnvironmentSelector "epac-25-02-0"

Sync-ALZPolicyFromLibrary: A parameter cannot be found that matches parameter name 'Tag'.
```

## Problem 2
The cmdlet `New-ALZPolicyDefaultStructure` implements the `-Tag` parameter, however the switch-statement overrides $tag on every run.

## Problem 2.1
Since $tag always has a value, the `if ($Tag)` statement will alwasy be true

