### PR TITLE
order managementGroupNameMappings in ALZPolicyDefaultStructure

### DIFF
--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -55,7 +55,7 @@ if ($LibraryPath -eq "") {
 }
 
 $jsonOutput = [ordered]@{
-    managementGroupNameMappings = @{}
+    managementGroupNameMappings = [ordered]@{}
     enforcementMode             = "Default"
     defaultParameterValues      = @{}
     enforceGuardrails           = @{

--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -57,7 +57,7 @@ if ($LibraryPath -eq "") {
 $jsonOutput = [ordered]@{
     managementGroupNameMappings = [ordered]@{}
     enforcementMode             = "Default"
-    defaultParameterValues      = @{}
+    defaultParameterValues      = [ordered]@{}
     enforceGuardrails           = @{
         deployments = @()
     }


### PR DESCRIPTION
## Issue
comparing the generated file `alz.policy_default_structure.epac.jsonc` between to releases is hard when the managementGroupNameMappings is not ordered.

## Steps to reproduce
```powershell
New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions-demo -Type ALZ -Tag "platform/alz/2024.11.0" -PacEnvironmentSelector "epac"
Rename-Item -Path ".\Definitions-demo\policyStructures\alz.policy_default_structure.epac.jsonc" -NewName alz.policy_default_structure.epac.v2024.11.0.jsonc

New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions-demo -Type ALZ -Tag "platform/alz/2025.02.0" -PacEnvironmentSelector "epac"
Rename-Item -Path ".\Definitions-demo\policyStructures\alz.policy_default_structure.epac.jsonc" -NewName alz.policy_default_structure.epac.v2025.02.0.jsonc
```

### now compare the two files
<img width="1186" height="811" alt="image" src="https://github.com/user-attachments/assets/9a5c567d-d1e5-435a-9fae-65c984e51932" />


### comparison with changes in this PR
<img width="1217" height="681" alt="image" src="https://github.com/user-attachments/assets/8b5fd104-e1b9-4068-9678-de62af67b2f2" />
