### PR TITLE
Add epacCloudEnvironments property validation

### DIFF
--- a/Schemas/policy-assignment-schema.json
+++ b/Schemas/policy-assignment-schema.json
@@ -9,7 +9,16 @@
             "type": "object"
         },
         "epacCloudEnvironments": {
-            "type": "object"
+            "type": "array",
+            "maxItems": 3,
+            "uniqueItems": true,
+            "items": {
+                "enum": [
+                    "AzureCloud",
+                    "AzureChinaCloud",
+                    "AzureUSGovernment"
+                ]
+            }
         },
         "definitionEntry": {
             "type": "object",

--- a/Schemas/policy-definition-schema.json
+++ b/Schemas/policy-definition-schema.json
@@ -28,6 +28,18 @@
                         },
                         "category": {
                             "type": "string"
+                        },
+                        "epacCloudEnvironments": {
+                            "type": "array",
+                            "maxItems": 3,
+                            "uniqueItems": true,
+                            "items": {
+                                "enum": [
+                                    "AzureCloud",
+                                    "AzureChinaCloud",
+                                    "AzureUSGovernment"
+                                ]
+                            }
                         }
                     },
                     "required": [

--- a/Schemas/policy-set-definition-schema.json
+++ b/Schemas/policy-set-definition-schema.json
@@ -28,6 +28,18 @@
                         },
                         "category": {
                             "type": "string"
+                        },
+                        "epacCloudEnvironments": {
+                            "type": "array",
+                            "maxItems": 3,
+                            "uniqueItems": true,
+                            "items": {
+                                "enum": [
+                                    "AzureCloud",
+                                    "AzureChinaCloud",
+                                    "AzureUSGovernment"
+                                ]
+                            }
                         }
                     },
                     "required": [


### PR DESCRIPTION
Adds validation for epacCloudEnvironments property in assignment, policy, and policyset schemas pursuant to #1011

If present, each of the above schemas will validate that the epacCloudEnvironments property is an array of strings containing at least one but not more than three unique values of "AzureCloud", "AzureChinaCloud" and "AzureUSGovernment".
