### PR TITLE
Add lighthouse sub role assignment

### DIFF
--- a/Docs/settings-global-setting-file.md
+++ b/Docs/settings-global-setting-file.md
@@ -102,9 +102,10 @@ EPAC has a concept of an environment identified by a string (unique per reposito
     - Policy Definitions, Policy Set Definitions and Policy Exemptions - `metadata.deployedBy`.
     - Policy Assignments - `metadata.assignedBy` since Azure Portal displays it as 'Assigned by'.
     - Role Assignments - add the value to the `description` field since Role assignments do not contain `metadata`.
-  - `managedTenant`: Used when the `pacEnvironment` is in a lighthouse managed tenant, [see this example](#example-for-lighthouse-manged-tenant) It must contain:
-    - `managingTenantId` - The tenantId of the managing tenant.
-    - `managingTenantRootScope` - An array of all subscriptions that will need `additionalRoleAssignments` deployed to them.
+    - `managedSubscription` - True or False (defult is false).  Set to True if this is a lighthouse "cast" subscription, also refered to as a managed subscription.  This allows for role assignments to occur on these types of subscriptions.
+  - `managedTenant`: Used when the `pacEnvironment` is in lighthouse managing tenant to keep information about scopes that you manage and may need to grant your policies RBAC access to at those managed scopes, [see this example](#example-for-lighthouse-manged-tenant) It must contain:
+    - `managedTenantId` - The tenantId of the tenant containing the managed subscription.
+    - `managedTenantScopes` - An array of all subscriptions in managed tenant that will need `additionalRoleAssignments` deployed to them for policies in the managing tenant.  This is to allow policies in a managing tenant/subscription to have access to resources in the managed subscription(s).  For example, if deploying a diagnostic settings policy to a managing tenant scope, and you want to write the diagnostics data to a LAW in the managed tenant/subscription, the subscription containing that LAW should be listed in this array.
 - `defaultContext`: In rare cases (typically only when deploying to a lighthouse managed tenant) the default context (Get-azContext) of a user/SPN running a plan will  
 be set to a subscription where that user/SPN does not have sufficient privileges.  Some checks have been built in so that in some cases when this happens EPAC is able to fix the context issue.  When it is not, a `defaultContext` subscription name must be provided.  This can be any subscription within the `deploymentRootScope`.
 
@@ -179,9 +180,9 @@ Resource Group patterns allow us to exclude "special" managed Resource Groups. T
             "pacSelector": "lightHouseTenant",
             "cloud": "AzureCloud",
             "tenantId": "22000000-0000-0000-0000-000000000000",
-            "managingTenant": {
-                "managingTenantId": "11000000-0000-0000-0000-000000000000",
-                "managingTenantRootScope": [
+            "managedTenant": {
+                "managedTenantId": "11000000-0000-0000-0000-000000000000",
+                "managedTenantScopes": [
                     "/subscriptions/00000000-0000-0000-0000-000000000000",
                     "/subscriptions/00000000-0000-0000-0000-000000000000"
                 ]

--- a/Schemas/global-settings-schema.json
+++ b/Schemas/global-settings-schema.json
@@ -32,20 +32,23 @@
                     "managedIdentityLocation": {
                         "type": "string"
                     },
-                    "managingTenant": {
+                    "managedSubscription": {
+                        "type": "boolean"
+                    },
+                    "managedTenant": {
                         "type": "array",
                         "item": [
                             {
-                                "managingTenantId": "string"
+                                "managedTenantId": "string"
                             },
                             {
-                                "managingTenantRootScopes": "array"
+                                "managedTenantScopes": "array"
                             }
                         ],
                         "additionalProperties": false,
                         "required": [
-                            "managingTenantId",
-                            "managingTenantRootScopes"
+                            "managedTenantId",
+                            "managedTenantScopes"
                         ]
                     },
                     "deploymentRootScope": {

--- a/Scripts/Deploy/Deploy-RolesPlan.ps1
+++ b/Scripts/Deploy/Deploy-RolesPlan.ps1
@@ -98,7 +98,7 @@ else {
                 $null = Remove-AzRoleAssignmentRestMethod -RoleAssignmentId $roleAssignment.id -ApiVersion $pacEnvironment.apiVersions.roleAssignments
             }
             else {
-                $null = Remove-AzRoleAssignmentRestMethod -RoleAssignmentId $roleAssignment.id -TenantId $pacEnvironment.managingTenantId -ApiVersion $pacEnvironment.apiVersions.roleAssignments
+                $null = Remove-AzRoleAssignmentRestMethod -RoleAssignmentId $roleAssignment.id -TenantId $pacEnvironment.managedTenantId -ApiVersion $pacEnvironment.apiVersions.roleAssignments
             }
 
         }
@@ -144,7 +144,7 @@ else {
             elseif (-not $assignmentById.ContainsKey($policyAssignmentId)) {
                 $null = $assignmentById.Add($policyAssignmentId, $principalId)
             }
-            Set-AzRoleAssignmentRestMethod -RoleAssignment $roleAssignment -ApiVersion $pacEnvironment.apiVersions.roleAssignments
+            Set-AzRoleAssignmentRestMethod -RoleAssignment $roleAssignment -PacEnvironment $pacEnvironment
         }
         Write-Information ""
     }
@@ -155,7 +155,7 @@ else {
 
         # Get identities for policy assignments from plan or by calling the REST API to retrieve the Policy Assignment
         foreach ($roleAssignment in $updatedRoleAssignments) {
-            Set-AzRoleAssignmentRestMethod -RoleAssignment $roleAssignment -ApiVersion $pacEnvironment.apiVersions.roleAssignments
+            Set-AzRoleAssignmentRestMethod -RoleAssignment $roleAssignment -PacEnvironment $pacEnvironment
         }
         Write-Information ""
     }

--- a/Scripts/Helpers/Get-AzPolicyAssignments.ps1
+++ b/Scripts/Helpers/Get-AzPolicyAssignments.ps1
@@ -22,7 +22,7 @@ function Get-AzPolicyAssignments {
     $uniquePrincipalIds = @{}
     foreach ($policyResource in $policyResources) {
         $resourceTenantId = $policyResource.tenantId
-        if ($resourceTenantId -in @($null, "", $environmentTenantId)) {
+        if (($resourceTenantId -in @($null, "", $environmentTenantId)) -or $PacEnvironment.managedSubscription -eq $true) {
             $id = $policyResource.id
             $testId = $id
             $properties = Get-PolicyResourceProperties $policyResource
@@ -151,9 +151,9 @@ function Get-AzPolicyAssignments {
             $null = $roleDefinitions.AddRange($roleDefinitionsLocal)
         }
             
-        if ($null -ne $PacEnvironment.managingTenantId) {
-            foreach ($subscription in $PacEnvironment.managingTenantRootScope) {
-                $remoteAssignments = Get-AzRoleAssignmentsRestMethod -Scope $subscription -ApiVersion $PacEnvironment.apiVersions.roleAssignments -Tenant $PacEnvironment.managingTenantId
+        if ($null -ne $PacEnvironment.managedTenantId) {
+            foreach ($subscription in $PacEnvironment.managedTenantScopes) {
+                $remoteAssignments = Get-AzRoleAssignmentsRestMethod -Scope $subscription -ApiVersion $PacEnvironment.apiVersions.roleAssignments -Tenant $PacEnvironment.managedTenantId
                 foreach ($assignment in $remoteAssignments) {
                     #if the remote assignment is attached to a principal we are looking at then add to the known role assignments object ($roleAssignments)
                     if ($uniquePrincipalIds.ContainsKey($assignment.properties.principalId)) {

--- a/Scripts/Helpers/Get-AzPolicyExemptions.ps1
+++ b/Scripts/Helpers/Get-AzPolicyExemptions.ps1
@@ -59,7 +59,7 @@ function Get-AzPolicyExemptions {
 
     foreach ($policyResource in $policyResources) {
         $resourceTenantId = $policyResource.tenantId
-        if ($resourceTenantId -in @($null, "", $environmentTenantId)) {
+        if (($resourceTenantId -in @($null, "", $environmentTenantId)) -or $PacEnvironment.managedSubscription -eq $true) {
             $properties = Get-PolicyResourceProperties $policyResource
 
             $id = $policyResource.id

--- a/Scripts/Helpers/Get-AzPolicyOrSetDefinitions.ps1
+++ b/Scripts/Helpers/Get-AzPolicyOrSetDefinitions.ps1
@@ -39,7 +39,7 @@ function Get-AzPolicyOrSetDefinitions {
     $policyResources = Search-AzGraphAllItems -Query $query -ProgressItemName $progressItemName -ProgressIncrement $progressIncrement
     foreach ($policyResource in $policyResources) {
         $resourceTenantId = $policyResource.tenantId
-        if ($resourceTenantId -in @($null, "", $environmentTenantId)) {
+        if (($resourceTenantId -in @($null, "", $environmentTenantId)) -or $PacEnvironment.managedSubscription -eq $true) {
             $id = $policyResource.id
             $testId = $id
             $included, $resourceIdParts = Confirm-PolicyResourceExclusions `

--- a/Scripts/Helpers/Get-AzPolicyResources.ps1
+++ b/Scripts/Helpers/Get-AzPolicyResources.ps1
@@ -212,7 +212,7 @@ function Get-AzPolicyResources {
         Write-Information "    Principal Ids         = $($numberPrincipalIds)"
         Write-Information "    With Role Assignments = $($numberPrincipalIdsWithRoleAssignments)"
         Write-Information "    Role Assignments      = $($deployedPolicyResources.numberOfRoleAssignments)"
-        if ($PacEnvironment.managingTenantId) {
+        if ($PacEnvironment.managedTenantId) {
             Write-Information "    Remote Role Assignments = $($deployedPolicyResources.remoteAssignmentsCount)"
         }
     }

--- a/Scripts/Helpers/Get-GlobalSettings.ps1
+++ b/Scripts/Helpers/Get-GlobalSettings.ps1
@@ -88,23 +88,23 @@ function Get-GlobalSettings {
             if ($null -eq $managedIdentityLocation) {
                 Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector does not contain required managedIdentityLocation field."
             }
-
-            $managingTenantId = $pacEnvironment.managingTenant.managingTenantId
-            $managingTenantRootScope = $pacEnvironment.managingTenant.managingTenantRootScope
-            if ($null -ne $managingTenantId) {
-                if ($null -eq $pacEnvironment.managingTenant.managingTenantRootScope) {
-                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector element managingTenantRootScope must have a valid value when managingTenantID has a value."
+            $managedSubscription = $pacEnvironment.managedSubscription
+            $managedTenantId = $pacEnvironment.managedTenant.managedTenantId
+            $managedTenantScopes = $pacEnvironment.managedTenant.managedTenantScopes
+            if ($null -ne $managedTenantId) {
+                if ($null -eq $pacEnvironment.managedTenant.managedTenantScopes) {
+                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector element managedTenantScopes must have a valid value when managedTenantID has a value."
                 }
                 $objectGuid = [System.Guid]::empty
                 # Returns True if successfully parsed, otherwise returns False.
-                $isGUID = [System.Guid]::TryParse($managingTenantId, [System.Management.Automation.PSReference]$objectGuid)
+                $isGUID = [System.Guid]::TryParse($managedTenantId, [System.Management.Automation.PSReference]$objectGuid)
                 if ($isGUID -ne $true) {
-                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector field managingTenant ($managingTenantId) must be a GUID."
+                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector field managedTenant ($managedTenantId) must be a GUID."
                 }
             }
-            elseif ($null -ne $managingTenantRootScope) {
-                if ($null -eq $managingTenantId) {
-                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector element managingTenantID must be a valid GUID when managingTenantRootScope has a value."
+            elseif ($null -ne $managedTenantScopes) {
+                if ($null -eq $managedTenantId) {
+                    Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "Global settings error: pacEnvironment $pacSelector element managedTenantID must be a valid GUID when managedTenantScopes has a value."
                 }
             }
 
@@ -333,8 +333,9 @@ function Get-GlobalSettings {
                 deployedBy                          = $deployedBy
                 cloud                               = $cloud
                 tenantId                            = $tenantId
-                managingTenantId                    = $managingTenantId
-                managingTenantRootScope             = $managingTenantRootScope
+                managedTenantId                     = $managedTenantId
+                managedTenantScopes                = $managedTenantScopes
+                managedSubscription                 = $managedSubscription
                 deploymentRootScope                 = $deploymentRootScope
                 defaultContext                      = $defaultContext
                 policyDefinitionsScopes             = $policyDefinitionsScopes


### PR DESCRIPTION
Add the ability for MSPs to manage policy, including DINE/Modify type policies that require role assignments, in customer subscriptions cast in to their tenant with lighthouse.