### PR TITLE
Add StrictMode Parameter, Fix Policy Documentation Generation Errors and excludeScopeTypes added to   documentAllAssignments

### DIFF
--- a/Scripts/Helpers/Out-DocumentationForPolicyAssignments.ps1
+++ b/Scripts/Helpers/Out-DocumentationForPolicyAssignments.ps1
@@ -380,7 +380,7 @@ function Out-DocumentationForPolicyAssignments {
                                 $hasParameters = $true
                                 $markdownMaxParameterLength = 42
                                 if ($DocumentationSpecification.markdownMaxParameterLength) {
-                                    $markdownMaxParameterLength = $DocumentationSpecification.markdownMaxParameterLength
+                                    $markdownMaxParameterLength = [int]($DocumentationSpecification.markdownMaxParameterLength | Select-Object -First 1)
                                     if ($markdownMaxParameterLength -lt 16) {
                                         Write-Error "markdownMaxParameterLength must be at least 16; it is $markdownMaxParameterLength" -ErrorAction Stop
                                     }

--- a/Scripts/Operations/Build-PolicyDocumentation.ps1
+++ b/Scripts/Operations/Build-PolicyDocumentation.ps1
@@ -20,6 +20,9 @@
 .PARAMETER IncludeManualPolicies
     Include Policies with effect Manual. Default: do not include Policies with effect Manual.
 
+.PARAMETER StrictMode
+    When enabled (default), the script will fail with an error if Policy Definitions referenced by assignments are not found. When disabled, shows warnings and continues.
+
 .EXAMPLE
     Build-PolicyDocumentation.ps1 -DefinitionsRootFolder "C:\PAC\Definitions" -OutputFolder "C:\PAC\Output" -Interactive
     Builds documentation from instructions in policyDocumentations folder reading the deployed Policy Resources from the EPAC environment.
@@ -31,6 +34,10 @@
 .EXAMPLE
     Build-PolicyDocumentation.ps1 -DefinitionsRootFolder "C:\PAC\Definitions" -OutputFolder "C:\PAC\Output" -Interactive -SuppressConfirmation
     Builds documentation from instructions in policyDocumentations folder reading the deployed Policy Resources from the EPAC environment. The script prompts for the PAC environment and uses the default definitions and output folders. It suppresses prompt for confirmation to delete existing file in interactive mode.
+
+.EXAMPLE
+    Build-PolicyDocumentation.ps1 -StrictMode:$false
+    Builds documentation in non-strict mode. The script will show warnings and continue if any Policy Definitions referenced by assignments are not found, instead of failing with an error.
 
 .LINK
     https://azure.github.io/enterprise-azure-policy-as-code/#deployment-scripts
@@ -64,7 +71,10 @@ param (
     [string] $pacSelector,
 
     [parameter(Mandatory = $false, HelpMessage = "Will only document assignments that are managed by your defined PAC Owner", Position = 0)]
-    [switch] $OnlyCheckManagedAssignments
+    [switch] $OnlyCheckManagedAssignments,
+
+    [parameter(Mandatory = $false, HelpMessage = "When enabled (default), the script will fail with an error if Policy Definitions referenced by assignments are not found. When disabled, shows warnings and continues.")]
+    [switch] $StrictMode = $true
 )
 
 # Dot Source Helper Scripts
@@ -298,7 +308,8 @@ foreach ($file in $files) {
                     -PacEnvironmentSelector $currentPacEnvironmentSelector `
                     -AssignmentArray $assignmentArray `
                     -PolicyResourceDetails $policyResourceDetails `
-                    -CachedAssignmentsDetails $cachedAssignmentsDetails
+                    -CachedAssignmentsDetails $cachedAssignmentsDetails `
+                    -StrictMode:$StrictMode
 
                 # Flatten Policy lists in Assignments and reconcile the most restrictive effect for each Policy
                 $flatPolicyList = Convert-PolicyResourcesDetailsToFlatList `
@@ -489,7 +500,8 @@ foreach ($file in $files) {
                     -PacEnvironmentSelector $currentPacEnvironmentSelector `
                     -AssignmentArray $assignmentArray `
                     -PolicyResourceDetails $policyResourceDetails `
-                    -CachedAssignmentsDetails $cachedAssignmentsDetails
+                    -CachedAssignmentsDetails $cachedAssignmentsDetails `
+                    -StrictMode:$StrictMode
 
                 # Remove entries if not managed by PAC
                 if ($OnlyCheckManagedAssignments) {


### PR DESCRIPTION
This pull request introduces improvements to error handling and configuration flexibility in the policy documentation scripts. The most significant changes are the addition of a `StrictMode` parameter to control error behavior when referenced policy definitions are missing, enhancements to how exclusions and skips are handled based on configuration, and improved robustness in parameter parsing.

**Error handling and configuration flexibility:**

* Added a `StrictMode` switch parameter (default: enabled) to `Build-PolicyDocumentation.ps1` and `Get-PolicyAssignmentsDetails.ps1`. When enabled, the script errors out if referenced policy definitions or sets are missing; when disabled, it logs warnings and continues. This allows users to choose between strict validation and more permissive execution. [[1]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cR23-R25) [[2]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cL67-R77) [[3]](diffhunk://#diff-9d04d92d3332e4269b705aec6ed2f80a0068a929e0b01ed2202c8b6dafe5dc23L7-R8) [[4]](diffhunk://#diff-9d04d92d3332e4269b705aec6ed2f80a0068a929e0b01ed2202c8b6dafe5dc23R48-R55) [[5]](diffhunk://#diff-9d04d92d3332e4269b705aec6ed2f80a0068a929e0b01ed2202c8b6dafe5dc23R65-R81) [[6]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cL301-R312) [[7]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cL492-R546)

* Updated documentation and usage examples to reflect the new `StrictMode` parameter, including how to run the script in non-strict mode.

**Assignment and exclusion logic improvements:**

* Improved logic for handling `excludeScopeTypes`, `skipPolicyAssignments`, and `skipPolicyDefinitions` in `Build-PolicyDocumentation.ps1` to support both object and array configurations, ensuring correct exclusion and skipping of assignments and definitions based on the current configuration. [[1]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cR386-R409) [[2]](diffhunk://#diff-67cad27ef4ff973b49cde47dbe8ecb3762ef287f27659b1eddfce704ce3fad4cR423-R449)

**Parameter parsing robustness:**

* Improved parsing of `markdownMaxParameterLength` in `Out-DocumentationForPolicyAssignments.ps1` to ensure it is always cast to an integer and respects a minimum value, preventing errors from unexpected input types.