### PR TITLE
Update policy-documentation-schema to eliminate validation warnings

### DIFF
--- a/Schemas/policy-documentation-schema.json
+++ b/Schemas/policy-documentation-schema.json
@@ -47,8 +47,7 @@
                         },
                         "required": [
                             "enabled",
-                            "pacEnvironment",
-                            "title"
+                            "pacEnvironment"
                         ]
                     }
                 },
@@ -63,7 +62,7 @@
                             },
                             "environmentCategories": {
                                 "type": "array",
-                                "minItems": 1,
+                                "minItems": 0,
                                 "items": {
                                     "type": "string"
                                 }


### PR DESCRIPTION
Following a minimal version of the [example in the docs](https://azure.github.io/enterprise-azure-policy-as-code/operational-scripts-documenting-policy/#document-all-assignments) shows some errors in the json according to the schema.

- documentAllAssignments.title is not a expected property
- documentationSpecifications.environmentCategories should either be allowed to be empty or not be required at all

<img width="1053" height="370" alt="image" src="https://github.com/user-attachments/assets/8864fce3-04d7-4a0c-90d5-ab47a0ca3c3f" />
