### PR TITLE
Fixing typos in documentation and script

### DIFF
--- a/Docs/guidance-lighthouse.md
+++ b/Docs/guidance-lighthouse.md
@@ -25,7 +25,7 @@ In your global settings file, update the lighthouse pacSelector to have the mana
                 "managedTenantId": "b617e3d0-18db-4bb6-afa1-662c906c2549",
                 "managedIdentityLocation": "eastus2",
 
-- **managedTenantId** - The tenant containing the lighthouse managed (joined) subsciptions.
+- **managedTenantId** - The tenant containing the lighthouse managed (joined) subscriptions.
 
 1. In the assignment file, add an additionalRoleAssignments section for the file or node so that the assignment knows that when assigning this policy at the managed scope pacEnvironment, it needs to perform an additional role assignment at the managing scope. 
 
@@ -57,7 +57,7 @@ Before any EPAC functionality can work, you must first provide the service princ
     1. Click "Manage your Customers"
     1. Click "Create ARM Template"
     1. Give the offer a name and description.
-    1. Choose the scopt your will request to manage
+    1. Choose the scope your will request to manage
     1. Click "+ Add authorization"
         1. Choose "Principal type" (Service Principal for EPAC)
         1. Select your principal

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -92,7 +92,7 @@ Microsoft can identify the deployments of the Azure Resource Manager with the de
 
 ### Opt out of telemetry data collection `telemetryOptOut`
 
-To opt-out of this tracking, we have included a settings in `global-settings.jsonc` called `telemetryOptOut`. If you would like to disable this tracking, then simply [set this value](settings-global-setting-file.md/#opt-out-of-telemetry-data-collection-telemetryoptout) to `true` (default is `false`).
+To opt-out of this tracking, we have included a setting in `global-settings.jsonc` called `telemetryOptOut`. If you would like to disable this tracking, then simply [set this value](settings-global-setting-file.md/#opt-out-of-telemetry-data-collection-telemetryoptout) to `true` (default is `false`).
 
 If you are happy with leaving telemetry tracking enabled, no changes are required.
 

--- a/Docs/operational-scripts-reference.md
+++ b/Docs/operational-scripts-reference.md
@@ -36,7 +36,7 @@ Include Policies with effect Manual. Default: do not include Policies with effec
 
 ## Script `New-AzRemediationTasks`
 
-The New-AzRemediationTasks PowerShell creates remediation tasks for all non-compliant resources in the current AAD tenant. If one or multiple remediation tasks fail, their respective objects are added to a PowerShell variable that is outputted for later use in the Azure DevOps Pipeline.
+The New-AzRemediationTasks PowerShell creates remediation tasks for all non-compliant resources in the current Entra ID tenant. If one or multiple remediation tasks fail, their respective objects are added to a PowerShell variable that is outputted for later use in the Azure DevOps Pipeline.
 
 ```ps1
 New-AzRemediationTasks [[-PacEnvironmentSelector] <String>] [-DefinitionsRootFolder <String>] [-Interactive <Boolean>] [-OnlyCheckManagedAssignments] [-PolicyDefinitionFilter <String[]>] [-PolicySetDefinitionFilter <String[]>] [-PolicyAssignmentFilter <String[]>] [-PolicyEffectFilter <String[]>] [-NoWait] [-TestRun] [-Confirm] [<CommonParameters>]

--- a/Scripts/Operations/New-AzRemediationTasks.ps1
+++ b/Scripts/Operations/New-AzRemediationTasks.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
 This PowerShell script creates remediation tasks for all non-compliant resources in the current
-Azure Active Directory (AAD) tenant.
+Entra ID tenant.
 
 .DESCRIPTION
 The New-AzRemediationTasks.ps1 PowerShell creates remediation tasks for all non-compliant resources
-in the current AAD tenant. If one or multiple remediation tasks fail, their respective objects are
+in the current Entra ID tenant. If one or multiple remediation tasks fail, their respective objects are
 added to a PowerShell variable that is outputted for later use in the Azure DevOps Pipeline.
 
 .PARAMETER PacEnvironmentSelector


### PR DESCRIPTION
This pull request updates documentation and scripts to reflect the rebranding of Azure Active Directory (AAD) to Entra ID, and also addresses minor spelling and wording corrections across several files.

**Branding updates:**
* Updated references from "Azure Active Directory (AAD) tenant" to "Entra ID tenant" in both the documentation (`Docs/operational-scripts-reference.md`) and the `New-AzRemediationTasks.ps1` script to ensure terminology is current and consistent. 

**Documentation corrections:**
* Fixed spelling errors in `Docs/guidance-lighthouse.md`, correcting "subsciptions" to "subscriptions" and "scopt your will request to manage" to "scope your will request to manage" for improved clarity.
* Corrected wording in `Docs/index.md` from "settings" to "setting" for accuracy in describing the `telemetryOptOut` configuration.