### PR TITLE
Jh/hkrepscope

### DIFF
--- a/Scripts/Helpers/Add-HelperScripts.ps1
+++ b/Scripts/Helpers/Add-HelperScripts.ps1
@@ -156,6 +156,8 @@ $scriptRoot = Split-Path $PSScriptRoot -Parent
 . "$PSScriptRoot/Update-HydrationModuleToSupportedVersion.ps1"
 . "$PSScriptRoot/Update-HydrationStarterKitAssignmentScope.ps1"
 . "$PSScriptRoot/Write-HydrationLogFile.ps1"
+. "$PSScriptRoot/Get-HydrationMessageBlock.ps1"
+. "$PSScriptRoot/Get-HydrationQuestionList.ps1"
 
 . "$PSScriptRoot/../HydrationKit/Build-HydrationDeploymentPlans.ps1"
 . "$PSScriptRoot/../HydrationKit/Copy-HydrationManagementGroupHierarchy.ps1"

--- a/Scripts/Helpers/Get-HydrationEpacRepo.ps1
+++ b/Scripts/Helpers/Get-HydrationEpacRepo.ps1
@@ -8,8 +8,9 @@ function Get-HydrationEpacRepo {
     if (Test-Path $RepoRoot) {
         $RepoRoot = Resolve-Path $RepoRoot
         $repoTempPath = Join-Path $RepoRoot "temp"
-        $starterKitSourcePath = Join-Path $repoTempPath "StarterKit" "*"
-        $starterKitDestinationPath = Join-Path $RepoRoot "StarterKit"
+        # $starterKitSourcePath = Join-Path $repoTempPath "StarterKit" "*"
+        # $starterKitDestinationPath = Join-Path $RepoRoot "StarterKit"
+        $starterKitSourcePath = Join-Path $repoTempPath "StarterKit"
         Write-Host "Downloading HydrationKit from GitHub to $RepoRoot" -ForegroundColor Green
         $url = "https://github.com/Azure/enterprise-azure-policy-as-code.git"
         if (!(Test-Path $repoTempPath)) {
@@ -34,7 +35,7 @@ function Get-HydrationEpacRepo {
                 return
             }
         }
-        $null = Copy-Item $starterKitSourcePath $starterKitDestinationPath -Recurse -Force -ErrorAction SilentlyContinue
+        $null = Copy-Item $starterKitSourcePath $RepoRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
     else {
         Write-Error "Error: Download failed, destination path $RepoRoot does not exist."

--- a/Scripts/Helpers/Get-HydrationMessageBlock.ps1
+++ b/Scripts/Helpers/Get-HydrationMessageBlock.ps1
@@ -1,0 +1,106 @@
+function Get-HydrationMessageBlock {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [int]
+        $TerminalWidth
+    )
+$messageJson = @"
+[
+    {
+        "displayPreliminaryTests": {
+            "TerminalWidth": $TerminalWidth,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Blue",
+            "SmallRowCharacter": "-",
+            "DisplayText": "Summarizing Test Results",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        },
+        "gatherData": {
+            "TerminalWidth": $TerminalWidth,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Blue",
+            "SmallRowCharacter": "-",
+            "DisplayText": "Beginning Data Gathering",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        },
+        "uiStart": {
+            "TerminalWidth": $TerminalWidth,
+            "RowCharacterColor": "Blue",
+            "TextRowCharacterColor": "Cyan",
+            "SmallRowCharacter": "+",
+            "DisplayText": "Enterprise Policy as Code (EPAC) Hydration Kit",
+            "LargeRowCharacter": "=",
+            "Location": "Top"
+        },
+        "runPreliminaryTests": {
+            "TerminalWidth": $TerminalWidth,
+            "RowCharacterColor": "Blue",
+            "TextRowCharacterColor": "Yellow",
+            "SmallRowCharacter": "-",
+            "DisplayText": "Beginning Preliminary Tests",
+            "LargeRowCharacter": "+",
+            "Location": "Top"
+        },
+        "generateAnswerFile": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Blue",
+            "SmallRowCharacter": "+",
+            "DisplayText": "Beginning Interview Process to Define EPAC Deployment",
+            "LargeRowCharacter": "-",
+            "Location": "Top"
+        },
+        "displayAnswerData": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Blue",
+            "SmallRowCharacter": "-",
+            "DisplayText": "Summarizing Answers Provided/Generated",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        },
+        "writeAnswerFile": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Green",
+            "SmallRowCharacter": "+",
+            "DisplayText": "Updating Answer File",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        },
+        "importAnswerFile": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Green",
+            "SmallRowCharacter": "+",
+            "DisplayText": "Importing Answer File",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        },
+        "beginHydrationProcess": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Blue",
+            "SmallRowCharacter": "-",
+            "DisplayText": "Beginning Hydration Process",
+            "LargeRowCharacter": "-",
+            "Location": "Top"
+        },
+        "populateRepoDefinitions": {
+            "TerminalWidth": null,
+            "RowCharacterColor": "Yellow",
+            "TextRowCharacterColor": "Green",
+            "SmallRowCharacter": "+",
+            "DisplayText": "Using Answer Data to Generate Definitions Folder Contents",
+            "LargeRowCharacter": "-",
+            "Location": "Middle"
+        }
+    }
+]
+"@
+$json = $messageJson | ConvertFrom-Json -depth 4 -AsHashtable
+return $json
+}

--- a/Scripts/Helpers/Get-HydrationQuestionList.ps1
+++ b/Scripts/Helpers/Get-HydrationQuestionList.ps1
@@ -1,0 +1,293 @@
+function Get-HydrationQuestionList {
+$messageJson =  @"
+[
+    {
+    "confirmPrimaryTenant": {
+        "outputVariableName": "initialTenantId",
+        "loopId": "initial",
+        "questionIncrement": 1,
+        "displayText": "Azure Connection Validation",
+        "bodyHeader": "The primary tenant must be specified in order to determine where the deployment should take place, and where the EPAC Development environment should be created.",
+        "dataRequest": "Please confirm the tenant identified below is the primary tenant that you wish to interact with.",
+        "links": [],
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "The tenant GUID specified is correct.",
+            "No": "This is not the correct tenant GUID, I wish to quit and reconnect to the desired Azure Tenant."
+        }
+    },
+    "definePacOwnerId": {
+        "outputVariableName": "pacOwnerId",
+        "loopId": "initial",
+        "questionIncrement": 2,
+        "displayText": "Define Primary pacOwnerId",
+        "bodyHeader": "Define the pacOwnerId for the Main Tenant Intermediate Root Management Group",
+        "bodyText": "The pacOwnerId is the Id applied to policy objects deployed by EPAC to identify the source repo for the policy. This enables decentralized policy management, such as a situation where one repo might be managed by a Security team and another by an Operations team. While these can be combined into one repo, this is not always preferred.",
+        "dataRequest": "Please input a pacOwnerId for this EPAC instance, or leave blank to generate a random GUID...",
+        "links": [
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/settings-global-setting-file.md"
+        ],
+        "inputType": "string",
+        "allowNull": true 
+    },
+    "createIntermediateRootHierarchy": {
+        "outputVariableName": "createMainCaf3Hierarchy",
+        "loopId": "initial",
+        "questionIncrement": 3,
+        "displayText": "Create CAF3 Hierarchy in Main Tenant",
+        "bodyHeader": "Determine whether to create a custom hierarchy, or use the Caf3Hierarchy for the Tenant Intermediate Root Management Group. If this is chosen, a Caf3Hierarchy will be created under the Intermediate Root.",
+        "bodyText": "The Cloud Adoption Framework version 3 Hierarchy based recommendation for Azure Landing Zones is what Microsoft recommends for use within the Intermediate Root to help improve policy deployment efficiency. Unless the organization has a well-considered alternative, it is recommended that this be deployed even if it will not be used immediately in order to provide a destination to use in the migration planning process.",
+        "dataRequest": "Please confirm the decision to create the Caf3Hierarchy in the primary tenant...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository"
+        ],
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "Create the recommended hierarchy, which will be the root of a new pacSelector.",
+            "No": "Do not create the recommended hierarchy. This should only be chosen if the organization has a well considered hierarchical alternative."
+        }
+    },
+    "createIntermediateRoot": {
+        "outputVariableName": "createMainIntermediateRoot",
+        "loopId": "optionalCreatePrimaryIntermediateRoot",
+        "questionIncrement": 1,
+        "displayText": "Create Intermediate Root in Primary Tenant",
+        "bodyHeader": "Decide if the Hydration Kit should create the Tenant Intermediate Root group in the primary tenant.",
+        "bodyText": "The Cloud Adoption Framework version 3 Hierarchy based recommendation for Azure Landing Zones includes a Tenant Intermediate Root that should be treated as the Tenant Root for operational purposes. This is what Microsoft recommends for use to assist in a Least Privilege model. Choose No if you wish to define an alternate Hierarchy.",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository"
+        ],
+        "dataRequest": "Please confirm the decision to create the Tenant Intermediate Root in the primary tenant...",
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "Create the specified intermediate root, which will be the root of a new pacSelector.",
+            "No": "Do not create the specified intermediate root, which will cause the script to exit after the interview process completes as this was the choice specified to initiate the deployment. These decisions are mutually exclusive, review the plan."
+        }
+    },
+    "prefixCaf3Hierarchy": {
+        "outputVariableName": "mainCaf3Prefix",
+        "loopId": "optionalCreateMainCaf3Hierarchy",
+        "questionIncrement": 1,
+        "displayText": "Modify Names for CAF3 Hierarchy in Primary Tenant - Prefix",
+        "bodyHeader": "Add a prefix to apply to Management Groups created in the Main Tenant Intermediate Root Management Group hierarchy.",
+        "bodyText": "In order to prevent naming collisions, a prefix and/or suffix can be specified in order to help ensure a unique name value. For Example, a prefix of \"New\" would result in the \"Sandbox\" Management Group being updated to \"NewSandbox\"",
+        "dataRequest": "Please input a prefix for the Caf3Hierarchy that will be created in the primary tenant intermediate root group...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "suffixCaf3Hierarchy": {
+        "outputVariableName": "mainCaf3Suffix",
+        "loopId": "optionalCreateMainCaf3Hierarchy",
+        "questionIncrement": 2,
+        "displayText": "Modify Names for CAF3 Hierarchy in Primary Tenant - Suffix",
+        "bodyHeader": "If desired, add a suffix to apply to Management Groups created in the Main Tenant Intermediate Root Management Group hierarchy.",
+        "bodyText": "In order to prevent naming collisions, a prefix and/or suffix can be specified in order to help ensure a unique name value. For Example, a suffix of \"Caf\" would result in the \"SandboxCaf\" Management Group being updated to \"Sandbox-epac\"",
+        "dataRequest": "Please input a suffix for the Caf3Hierarchy that will be created in the primary tenant intermediate root group...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "confirmMainRootName": { 
+        "outputVariableName": "mainTenantMainPacSelectorName",
+        "loopId": "corePacSelectors",
+        "questionIncrement": 1,
+        "displayText": "PacSelector for Main Tenant",
+        "bodyHeader": "Choose PacSelector Name for Main Tenant Intermediate Root Management Group",
+        "bodyText": "This PacSelector will be used by EPAC in the Global Settings file to identify the Main Tenant Intermediate Root Management Group and its children. This will be cloned for testing during the DevOps deployment testing.",
+        "dataRequest": "Please input a string value for the name of the Main Tenant Intermediate Root PacSelector, or simply press enter to accept the default value -- tenant01",
+        "links": [
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/settings-global-setting-file.md"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "confirmEpacParent": {
+        "outputVariableName": "epacParent",
+        "loopId": "corePacSelectors",
+        "questionIncrement": 2,
+        "displayText": "Parent for EPAC Development pacSelector",
+        "bodyHeader": "Choose Parent for EPAC copy of the Tenant Intermediate Root Management Group",
+        "bodyText": "This will be the parent for the EPAC copy of the Tenant Intermediate Root Management Group. This will be used to create a copy of the Tenant Intermediate Root Management Group for testing purposes, and SHOULD NOT be that copy of the Tenant Intermediate Root, but the Management Group it will be placed in. It is strongly recommended that the organization accept the default value.",
+        "dataRequest": "Please input a string value for the name of the Management Group in which this hierarchy should be created, or simply press enter to accept the default value -- Tenant Root",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/settings-global-setting-file.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-branching-flows.md"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "confirmDefaultManagedIdLocation": { 
+        "outputVariableName": "managedIdAssignmentLocation",
+        "loopId": "corePacSelectors",
+        "questionIncrement": 3,
+        "displayText": "Choose Managed ID Location",
+        "bodyHeader": "Managed ID Location for Main Tenant Intermediate Root Management Group and EPAC Management Group",
+        "bodyText": "All Deploy if Not Exist and Modify policies require a Managed Identity to be part of the definition of the policy in order to affect change within Azure. The Deploy-RolesPlan stage of the EPAC process will deploy the service principals required for those policies identified for deployment in the Build-DeploymentPlan stage of EPAC deployment. A list of available locations has been generated based on your current active connection.",
+        "dataRequest": "Please choose a location for the Managed Identity to be created using short name (no spaces) format...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-deploy-if-not-exists",
+            "https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-modify",
+            "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview",
+            "https://learn.microsoft.com/en-us/azure/governance/policy/how-to/remediate-resources?tabs=azure-portal"
+        ],
+        "inputType": "string"
+    },
+    "confirmEpacPrefix": { // Set logic to repeat if both are null
+        "outputVariableName": "epacPrefix",
+        "loopId": "epacModifier",
+        "questionIncrement": 1,
+        "displayText": "Modify Names for EPAC Environment - Prefix",
+        "bodyHeader": "Add a prefix to apply to Management Groups created to mimic the Main Tenant Intermediate Root Management Group hierarchy",
+        "bodyText": "This management group hierarchy will be used to test deployments for the Main Tenant Intermediate Root Management Group hierarchy. In order to prevent naming collisions, a prefix and/or suffix can be specified in order to help ensure a unique name value.For Example, a prefix of \"epac-\" would result in the \"Sandbox\" Management Group being updated to \"epac-Sandbox\"",
+        "dataRequest": "Please input a prefix for the EPAC Hierarchy that will be created to support pipeline operations...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-ado-pipelines.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-branching-flows.md"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "confirmEpacSuffix": {
+        "outputVariableName": "epacSuffix",
+        "loopId": "epacModifier",
+        "questionIncrement": 2,
+        "displayText": "Modify Names for EPAC Environment - Suffix",
+        "bodyHeader": "Choose a suffix and/or prefix to apply to the EPAC Development Management Group hierarchy",
+        "bodyText": "This management group hierarchy will be used to test deployments for the Main Tenant Intermediate Root Management Group hierarchy. In order to prevent naming collisions, a prefix and/or suffix MUST be specified in order to help ensure a unique name value. For Example, a suffix of \"-epacdev\" would result in the \"Sandbox\" Management Group being updated to \"Sandbox-epacdev\" in the EPAC development envirnoment.",
+        "dataRequest": "Please input a suffix for the EPAC Hierarchy that will be created to support pipeline operations...",
+        "links": [
+            "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-groups-in-the-azure-landing-zone-accelerator-and-alz-bicep-repository",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-ado-pipelines.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-branching-flows.md"
+        ],
+        "inputType": "string",
+        "allowNull": true
+    },
+    "importExistingPolicies": {
+        "outputVariableName": "importExistingPolicies",
+        "loopId": "policyDecisions",
+        "questionIncrement": 1,
+        "displayText": "Decision - Import Existing Policies",
+        "bodyHeader": "Decide if existing policies should be imported to EPAC for the Main Tenant Intermediate Root Management Group.",
+        "bodyText": "If selected, EPAC will export the policy objects assigned within the scope of the Main Tenant Intermediate Root Management Group and define assignments in EPAC for them, using the newly defined pacOwnerId to identify it as being managed by EPAC. This is an important step in enabling EPAC based policy deployment to move from \"ownedOnly\" to \"full\".",
+        "dataRequest": "Please choose Yes or No to indicate if existing policies should be imported to EPAC...",
+        "links": [
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/settings-desired-state.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/policy-assignments.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/policy-exemptions.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/policy-set-definitions.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/policy-set-definitions.md"
+        ],
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "Import existing policies within the defined scope for EPAC management.",
+            "No": "Do not import the existing polcies for the defined scope, this will be completed at a later time."
+        }
+    },
+    "importPci": {
+        "outputVariableName": "importPciDssPolicies",
+        "loopId": "policyDecisions",
+        "questionIncrement": 2,
+        "displayText": "Decision - Import PCI DSS Policies",
+        "bodyHeader": "Decide if a PCI-DSS PolicySet should be assigned as part of the initial EPAC deployment..",
+        "bodyText": "This can be useful for those organizations that need to evaluate their current state against the standard set of policies defined by Microsoft to evaluate against this standard.",
+        "dataRequest": "Please choose whether or not to deploy this policy...",
+        "links": [
+            "https://www.azadvertizer.net/azpolicyinitiativesadvertizer/c676748e-3af9-4e22-bc28-50feed564afb.html"
+        ],
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "Apply this policy as part of the initial EPAC deployment..",
+            "No": "Do not apply this policy as part of the initial EPAC deployment.."
+        }
+    },
+    "importNist80053": {
+        "outputVariableName": "importNist80053Policies",
+        "loopId": "policyDecisions",
+        "questionIncrement": 3,
+        "displayText": "Decision - Import NIST 800-53 v5 Policies",
+        "bodyHeader": "Decide if a NIST 800-53 v5 PolicySet should be assigned as part of the initial EPAC deployment..",
+        "bodyText": "This can be useful for those organizations that need to evaluate their current state against the standard set of policies defined by Microsoft to evaluate against this standard.",
+        "dataRequest": "Please choose whether or not to deploy this policy...",
+        "links": [],
+        "inputType": "optionList",
+        "menuOptions": {
+            "Yes": "Apply this policy as part of the initial EPAC deployment..",
+            "No": "Do not apply this policy as part of the initial EPAC deployment.."
+        }
+    },
+    "importAdditionalPolicySets": {
+        "outputVariableName": "importAdditionalPolicySets",
+        "loopId": "policyDecisions",
+        "questionIncrement": 4,
+        "displayText": "Decision - Add additional Built-In PolicySets",
+        "bodyHeader": "Additional PolicySet",
+        "bodyText": "This can be useful for those organizations that know what additional policies they would like to assign as part of the initial EPAC deployment.",
+        "dataRequest": "Please add a list in the format \"GUID1\",\"GUID2\" etc...",
+        "allowNull": true,
+        "links": [
+            "https://www.azadvertizer.net/azpolicyinitiativesadvertizer_all.html"
+        ],
+        "inputType": "string"
+    },
+    "useModuleorScript": { 
+        "outputVariableName": "codeExecutionType",
+        "loopId": "pipelineDecisions",
+        "questionIncrement": 1,
+        "displayText": "Choose EPAC Code Source for Pipeline",
+        "bodyHeader": "Define how EPAC code will be executed",
+        "bodyText": "Please choose how you would like the Pipeline to interact with EPAC code in order to run processes. This can use either the psGallery Module, or a local copy of the Enterprise Policy as Code source.",
+        "DataRequest": "Choose Module or Script...",
+        "inputType": "optionList",
+        "links": [
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/start-forking-github-repo.md"
+        ],
+        "menuOptions": {
+            "Module": "This choice will require that the EnterprisePolicyAsCode module in PSGallery be available in the pipeline(s).",
+            "Script": "This choice will require a local copy of the EPAC source code be available to the pipeline(s)."
+        }
+    },
+    "pipelinePlatform": {
+        "outputVariableName": "pipelinePlatform",
+        "loopId": "pipelineDecisions",
+        "questionIncrement": 2,
+        "displayText": "Choose the DevOps Platform In Use",
+        "bodyHeader": "Define the DevOps platform that will be used to deploy policy objects using EPAC",
+        "bodyText": "There are currently two platforms that are supported by EPAC for policy deployment. These are Github and Azure DevOps. If you are using a different platform, please choose \"Other\" and you will be prompted for the path to the root of the repository where the pipeline will be stored. A GitHub based pipeline will be placed in this location as a starting point for development of a custom pipeline for the platform in use.",
+        "DataRequest": "Please choose a platform...",
+        "links": [
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-github-actions.md",
+            "https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Docs/ci-cd-ado-pipelines.md",
+            "https://www.github.com",
+            "https://dev.azure.com"
+        ],
+        "inputType": "optionList",
+        "menuOptions": {
+            "GithubActions": "Pipelines hosted in Github.",
+            "AzureDevOps": "Pipelines hosted in Azure DevOps.",
+            "Other": "Pipelines hosted in any other platform."
+        }
+    },
+    "pipelineCustomPath": {
+        "outputVariableName": "pipelineCustomPath",
+        "loopId": "otherPipeline",
+        "questionIncrement": 1,
+        "displayText": "Define Pipeline Path",
+        "bodyHeader": "If you have a desired custom path for your pipeline storage, please list it here in a format that is a realtive path to the repo root directory.",
+        "bodyText": "As this is not a platform that EPAC has definitions for out of the box, we recommend choosing the appropriate custom path to place the pipelines at. Github style pipelines will be placed as these have similar formats to several other git based platforms, such as Gitlab. Example: pipelines/custompath",
+        "dataRequest": "Type the RELATIVE path from the root of the repo to the desired location for the pipeline to be stored...",
+        "links": [],
+        "inputType": "string"
+        }
+    }
+]
+"@
+return $messageJson | ConvertFrom-Json -depth 10 -AsHashtable
+}

--- a/Scripts/Helpers/New-HydrationAnswerSet.ps1
+++ b/Scripts/Helpers/New-HydrationAnswerSet.ps1
@@ -4,9 +4,9 @@ function New-HydrationAnswerSet {
         [Parameter(Mandatory = $true)]
         [string]
         $LoopId,
-        [Parameter(Mandatory = $true)]
-        [string]
-        $QuestionsFilePath,
+        # [Parameter(Mandatory = $true)]
+        # [string]
+        # $QuestionsFilePath,
         [Parameter(Mandatory = $true)]
         [string]
         $LogFilePath,
@@ -20,19 +20,19 @@ function New-HydrationAnswerSet {
         [switch]
         $UseUtc
     )
-    if (!(Test-Path $QuestionsFilePath)) {
-        Write-Error "Questions file not found at $QuestionsFilePath"
-        return "Failed, Questions file not found at $QuestionsFilePath...."
-    }
-    else {
-        $fullQuestionsList = Get-Content $QuestionsFilePath | ConvertFrom-Json -Depth 10 -AsHashtable
-        $questionsList = @{}
-        foreach ($questionKey in $fullQuestionsList.Keys) {
-            if ($fullQuestionsList.$questionKey.loopId -eq $LoopId) {
-                $questionsList.Add($questionKey, $fullQuestionsList.$questionKey)
-            }
+    # if (!(Test-Path $QuestionsFilePath)) {
+    #     Write-Error "Questions file not found at $QuestionsFilePath"
+    #     return "Failed, Questions file not found at $QuestionsFilePath...."
+    # }
+    # else {
+    $fullQuestionsList = Get-HydrationQuestionList
+    $questionsList = @{}
+    foreach ($questionKey in $fullQuestionsList.Keys) {
+        if ($fullQuestionsList.$questionKey.loopId -eq $LoopId) {
+            $questionsList.Add($questionKey, $fullQuestionsList.$questionKey)
         }
     }
+    # }
     $responseList = [ordered]@{}
     foreach ($question1 in $questionsList.Keys) {
         $responseList.Add($questionsList.$question1.outputVariableName, "Skipped")

--- a/Scripts/Helpers/New-HydrationSeparatorBlock.ps1
+++ b/Scripts/Helpers/New-HydrationSeparatorBlock.ps1
@@ -28,7 +28,11 @@ function New-HydrationSeparatorBlock {
     $smallRow = ($SmallRowCharacter * $TerminalWidth)
     $largeRow = ($LargeRowCharacter * $TerminalWidth)
     $modifiedDisplayText = " $DisplayText "
-    $textRow = -join (($SmallRowCharacter * ([math]::Floor(($TerminalWidth - $modifiedDisplayText.Length) / 2))), $modifiedDisplayText, ($SmallRowCharacter * ([math]::Ceiling(($TerminalWidth - $modifiedDisplayText.Length) / 2))))
+    $front = ([math]::Floor(($TerminalWidth - $modifiedDisplayText.Length) / 2))
+    $back = ([math]::Ceiling(($TerminalWidth - $modifiedDisplayText.Length) / 2))
+    if ($front -lt 0) { $front = 0 }
+    if ($back -lt 0) { $back = 0 } 
+    $textRow = -join (($SmallRowCharacter * $front), $modifiedDisplayText, ($SmallRowCharacter * $back))
     switch ($Location) {
         "Top" {
             Write-Host "`n`n$largeRow" -ForegroundColor $RowCharacterColor

--- a/Scripts/HydrationKit/Update-HydrationAssignmentDestination.ps1
+++ b/Scripts/HydrationKit/Update-HydrationAssignmentDestination.ps1
@@ -146,7 +146,7 @@ function Update-HydrationAssignmentDestination {
         }
         $outputFile = Join-Path $Output "UpdatedAssignmentDestination" "Definitions" "policyAssignments" $relativeFilePath
         if (!(Test-Path (Split-Path $outputFile))) {
-            New-Item -ItemType Directory -Path (Split-Path $outputFile) | Out-Null
+            $null = New-Item -ItemType Directory -Path (Split-Path $outputFile) | Out-Null
         }
         $assignmentData | ConvertTo-Json -Depth 100 | Set-Content -Path $outputFile
     }


### PR DESCRIPTION
- Feature: 
  - Enabled Script Execution of Hydration Kit
  
- Bug:
  - Install-HydrationEpac.ps1
    - Fixed question about creation of tenantIntermediateRoot to match change in logic to no longer test
    - Fixed capitalization bug in path join for exported content
  - Fixed broken hydration kit references in Add-Helper Scripts
  - Fixed inconsistent results caused by New-HydrationCaf3Hierarchy lacking the ability to create the Tenant Intermediate Root if it is not present
  - Removed Get-AzManagementGroupRestMethod, static requirement to stop was breaking tests that were intended to continue if failed, moved to Get-AzManagementGroup
  - Fixed bug that resulted in epac-dev scopes not being populated in some newly created assignments 
    

- Refinement: 
  - Moved all process temp files to temp folder, updated reference points accordingly
  - Added/Updated emotes to provide greater clarity
  - Removed CAF3 Root modification actions from process, the parameterized input value should not change
  - Consolidated temporary file locations during process for cleaner processing
  - Removed unintended emote in Scripts/HydrationKit/Update-HydrationAssignmentDestination.ps1
  - Scripts/HydrationKit/Install-HydrationEpac.ps1
    - Updated unclear help message 
    - Removed deprecated parameter (StarterKit)
    - Removed unused tests
    - Removed unneeded comments
    - Added additional error recovery
    - Began consolidating disparate variables into hashtables to simplify ongoing support 
    - Removed dependency on StarterKit from HydrationKit as this was causing problematic states
      - Imported via Scripts/Helpers/Get-HydrationQuestionList.ps1 and Scripts/Helpers/Get-HydrationMessageBlock.ps1
      - Updated Scripts/Helpers/New-HydrationAnswerSet.ps1 and Scripts/Helpers/New-HydrationSeparatorBlock.ps1 to leverage new approach
    - Enabled suppression of prompts that require no response to streamline additional test automation
