### PR TITLE
Correct array expression in JSON definition

### DIFF
--- a/Scripts/Helpers/RestMethods/Set-AzPolicyDefinitionRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Set-AzPolicyDefinitionRestMethod.ps1
@@ -26,6 +26,7 @@ function Set-AzPolicyDefinitionRestMethod {
 
     # Invoke the REST API
     $definitionJson = ConvertTo-Json $definition -Depth 100 -Compress
+    $definitionJson = $definitionJson.Replace('[[', '[')
     $response = Invoke-AzRestMethod -Path "$($DefinitionObj.id)?api-version=$ApiVersion" -Method PUT -Payload $definitionJson
 
     # Process response


### PR DESCRIPTION
Deploying a policy definition that contains an array (e.g. AMBA [CapacityUnits][1]) as the default value results in an error.

```PowerShell
▶ Creating and Updating Policies (1 items)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  • Setting policy definition: Deploy Network applicationGateways CapacityUnits Alert
Write-Error: C:\Program Files\PowerShell\Modules\EnterprisePolicyAsCode\11.2.2\functions\Deploy-PolicyPlan.ps1:151
Line |
 151 |              Set-AzPolicyDefinitionRestMethod -Definition $entry -ApiV …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Definition error 400 -- Deploy Network applicationGateways CapacityUnits Alert --{   "error": {     "code": "InvalidPolicyParameters",     "message": "A function or parameter in policy
     | 'd43ca9ef-6211-40ff-972e-fffb17923fc9' could not be validated. If using template functions, try following the tips in: https://aka.ms/policy-avoiding-template-failures. The inner exception
     | 'Evaluation result of language expression '[[parameters('MonitorDisableTagValues')]' is type 'String', expected type is 'Array'.'."   } }
```

The error occurs because `[[ (ARM template escaped brackets)` is used for policy expressions, but the script sends the payload directly via the REST API where single `[` is expected. The `[[` escaping is only needed when policy definitions are embedded in ARM templates.

[1]: https://github.com/Azure/azure-monitor-baseline-alerts/blob/main/services/Network/applicationGateways/templates/policy/CapacityUnits_d43ca9ef-6211-40ff-972e-fffb17923fc9.json