### PR TITLE
Cleaning out the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-Output/
-site/
-Definitions/
-temp/
-Tools/
+


### PR DESCRIPTION
As I have created my files within the EPAC repo, upon every release that I pull down, I am forced to clean up this .gitignore file from paths that should in fact not be ignored. Let's not merge local (dev) testing into an official release :-)