### PR TITLE
Update policy-exemption-schema.json

### DIFF
--- a/Schemas/policy-exemption-schema.json
+++ b/Schemas/policy-exemption-schema.json
@@ -14,13 +14,13 @@
                         "type": "string"
                     },
                     "description": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "exemptionCategory": {
                         "type": "string"
                     },
                     "expiresOn": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "scope": {
                         "type": "string"
@@ -32,7 +32,7 @@
                         "type": "string"
                     },
                     "policyDefinitionReferenceIds": {
-                        "type": "array"
+                        "type": ["array", "null"]
                     },
                     "policyDefinitionId": {
                         "type": "string"
@@ -47,10 +47,10 @@
                         "type": "string"
                     },
                     "resourceSelectors": {
-                        "type": "array"
+                        "type": ["array", "null"]
                     },
                     "assignmentScopeValidation": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "metadata": {
                         "type": "object"


### PR DESCRIPTION
Update the policy-exemption-schema so that it supports null values where they're possible.

When executing "Export-AzPolicyResources -ExemptionFiles json you retrieve all policies and exemptions.
Some values are null (which make sense) but they're not allowed by the schema.

Please merge and release in next EPAC version.

<img width="1445" height="746" alt="image" src="https://github.com/user-attachments/assets/cb7e47f7-bae4-49f7-a5f5-66b35e6ab64d" />
