### PR TITLE
added PolicySet Effect Documentation options

### DIFF
--- a/Docs/operational-scripts-documenting-policy.md
+++ b/Docs/operational-scripts-documenting-policy.md
@@ -100,6 +100,8 @@ Each file must contain one or both documentation topics, [`documentAssignments`]
             "pacEnvironment": "tenant",
             "fileNameStem": "contoso-compliance-policy-sets",
             "title": "Document interesting Policy Sets",
+			"includePolicySetList": true,
+            "policySetEffectsOneColumn": false,
             "policySets": [
                 {
                     "shortName": "ASB",
@@ -221,6 +223,8 @@ Each file must contain one or both documentation topics, [`documentAssignments`]
             "pacEnvironment": "tenant",
             "fileNameStem": "contoso-compliance-policy-sets",
             "title": "Document interesting Policy Sets",
+			"includePolicySetList": true,
+            "policySetEffectsOneColumn": false,
             "policySets": [
                 {
                     "shortName": "ASB",
@@ -249,6 +253,14 @@ Each file must contain one or both documentation topics, [`documentAssignments`]
     ]
 }
 ```
+
+### PolicySet documentation output options
+When using a larger number of PolicySets, you can choose to:
+- not include a list of all PolicySets ("includePolicySetList": false)
+- use just 1 column showing the PolicySets Effects ("policySetEffectsOneColumn": true,)
+For an example, review the file ["EPAC GitHub: documentPolicySets.jsonc"](https://github.com/Azure/enterprise-azure-policy-as-code/blob/main/Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc)
+
+
 ## Automating Azure DevOps Wiki Markdown
 
 * EPAC can be used to automate the population of your Azure DevOps Wiki pages with the generated markdown files. To do this, you must call "Build-PolicyDocumentation" with the parameter either the "WikiSPN" or "WikiClonePat". 

--- a/Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc
+++ b/Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc
@@ -3,13 +3,19 @@
     "documentPolicySets": [
         {
             "pacEnvironment": "<pacEnvironment>",
-            "fileNameStem": "MCSBv2",
-            "title": "MCSBv2",
+            "fileNameStem": "MyPolicySets",
+            "title": "My Policy Sets",
+			"includePolicySetList": true, // Set to false if you do not want the PolicySet List
+            "policySetEffectsOneColumn": false, //Set to true if you want just 1 column showing the effects per PolicySet, usefull if larger number of (custom) PolicySet are defined.
             "policySets": [
                 {
-                    "shortName": "MCSBv2",
-                    "id": "/providers/Microsoft.Authorization/policySetDefinitions/e3ec7e09-768c-4b64-882c-fcada3772047" // MCSBv2
-                }
+                    "shortName": "Azure Security Benchmark v3",
+                    "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8" // Azure Security Benchmark v3
+                } //,
+				//{
+                //    "shortName": "my-custom-definition",
+                //    "id": "/providers/Microsoft.Management/managementGroups/{myManagementGroup}/providers/Microsoft.Authorization/policySetDefinitions/my-custom-definition"
+                //},
             ],
             "environmentColumnsInCsv": [
                 "<pacEnvironment>"

--- a/Schemas/policy-documentation-schema.json
+++ b/Schemas/policy-documentation-schema.json
@@ -218,6 +218,12 @@
                     "title": {
                         "type": "string"
                     },
+					"includePolicySetList": {
+						"type": "boolean"
+					},
+					"policySetEffectsOneColumn": {
+						"type": "boolean"
+					},
                     "policySets": {
                         "type": "array",
                         "minItems": 1,

--- a/Scripts/Helpers/Out-DocumentationForPolicySets.ps1
+++ b/Scripts/Helpers/Out-DocumentationForPolicySets.ps1
@@ -43,29 +43,46 @@ function Out-DocumentationForPolicySets {
     }
 
     #region Policy Set List
-    $addedTableHeader = ""
-    $addedTableDivider = ""
-    $addedTableDividerParameters = ""
-    $null = $allLines.Add("`n$leadingHeadingHashtag# Policy Set (Initiative) List`n")
-    foreach ($item in $ItemList) {
-        $shortName = $item.shortName
-        $policySetId = $item.policySetId
-        $policySetDetail = $PolicySetDetails.$policySetId
-        $policySetDisplayName = $policySetDetail.displayName -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
-        $policySetDescription = $policySetDetail.description -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
-        $null = $allLines.Add("$leadingHeadingHashtag## $($shortName)`n")
-        $null = $allLines.Add("- Display name: $($policySetDisplayName)`n")
-        $null = $allLines.Add("- Type: $($policySetDetail.policyType)")
-        $null = $allLines.Add("- Category: $($policySetDetail.category)`n")
-        $null = $allLines.Add("$($policySetDescription)`n")
-
-        $addedTableHeader += " $shortName |"
-        $addedTableDivider += " :-------: |"
-        $addedTableDividerParameters += " :------- |"
+	if ($DocumentationSpecification.includePolicySetList -ne $null) {
+        $includePolicySetList = $DocumentationSpecification.includePolicySetList
     }
+    else {
+        $includePolicySetList = $true # default to including the policy set list if not specified
+    }
+    if ($includePolicySetList) {
+		$addedTableHeader = ""
+		$addedTableDivider = ""
+		$addedTableDividerParameters = ""
+		$null = $allLines.Add("`n$leadingHeadingHashtag# Policy Set (Initiative) List`n")
+		foreach ($item in $ItemList) {
+			$shortName = $item.shortName
+			$policySetId = $item.policySetId
+			$policySetDetail = $PolicySetDetails.$policySetId
+			$policySetDisplayName = $policySetDetail.displayName -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
+			$policySetDescription = $policySetDetail.description -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
+			$null = $allLines.Add("$leadingHeadingHashtag## $($shortName)`n")
+			$null = $allLines.Add("- Display name: $($policySetDisplayName)`n")
+			$null = $allLines.Add("- Type: $($policySetDetail.policyType)")
+			$null = $allLines.Add("- Category: $($policySetDetail.category)`n")
+			$null = $allLines.Add("$($policySetDescription)`n")
+
+			$addedTableHeader += " $shortName |"
+			$addedTableDivider += " :-------: |"
+			$addedTableDividerParameters += " :------- |"
+		}
+	}
     #endregion Policy Set List
 
-    #region Policy Effects
+	if ($DocumentationSpecification.policySetEffectsOneColumn -ne $null) {
+        $PolicySetEffectsOneColumn = $DocumentationSpecification.policySetEffectsOneColumn
+    }
+    else {
+        $PolicySetEffectsOneColumn = $false # default to use classic multi-column layout for policy effects if not specified
+    }
+
+    #region Policy Effects Multi-Column
+    if ( -not $PolicySetEffectsOneColumn) {
+		
     if ($DocumentationSpecification.markdownIncludeComplianceGroupNames) {
         $null = $allLines.Add("`n$leadingHeadingHashtag# Policy Effects by Policy`n")
         $null = $allLines.Add("| Category | Policy | Compliance |$addedTableHeader")
@@ -132,7 +149,79 @@ function Out-DocumentationForPolicySets {
             Write-Verbose "Skipping manual policy: $($_.name)"
         }
     }
-    #endregion Policy Effects
+    #endregion Policy Effects Multi-Column
+	
+	#region Policy Effects One Column
+    if ($PolicySetEffectsOneColumn) {
+        if ($DocumentationSpecification.markdownIncludeComplianceGroupNames) {
+            $null = $allLines.Add("`n$leadingHeadingHashtag# Policy Effects by Policy`n")
+            $null = $allLines.Add("| Category | Policy | Compliance | Effects |")
+            $null = $allLines.Add("| :------- | :----- | :---------- | :------ |")
+        }
+        else {
+            $null = $allLines.Add("`n$leadingHeadingHashtag# Policy Effects`n")
+            $null = $allLines.Add("| Category | Policy | Effects |")
+            $null = $allLines.Add("| :------- | :----- | :------ |")
+        }
+
+        $FlatPolicyList.Values | Sort-Object -Property { $_.category }, { $_.displayName } | ForEach-Object -Process {
+            $policySetList = $_.policySetList
+            $effectsByPolicySet = [System.Collections.ArrayList]::new()
+            $effectValue = "Unknown"
+            if ($null -ne $_.effectValue) {
+                $effectValue = $_.effectValue
+            }
+            else {
+                $effectValue = $_.effectDefault
+            }
+
+            if ($effectValue -ne "Manual" -or $IncludeManualPolicies) {
+                $groupNamesList = [System.Collections.ArrayList]::new()
+                foreach ($item in $ItemList) {
+                    $shortName = $item.shortName
+                    if ($policySetList.ContainsKey($shortName)) {
+                        $perPolicySet = $policySetList.$shortName
+                        $perPolicySetEffectValue = $perPolicySet.effectValue
+                        if ($null -eq $perPolicySetEffectValue -or [string]::IsNullOrWhiteSpace("$perPolicySetEffectValue")) {
+                            $perPolicySetEffectValue = $perPolicySet.effectDefault
+                        }
+                        if ($perPolicySetEffectValue.StartsWith("[if(contains(parameters('resourceTypeList')")) {
+                            $perPolicySetEffectValue = "SetByParameter"
+                        }
+                        $null = $effectsByPolicySet.Add("$shortName : **$perPolicySetEffectValue**")
+
+                        [array] $groupNames = $perPolicySet.groupNames
+                        if ($groupNames.Count -gt 0) {
+                            $groupNamesList.AddRange($groupNames)
+                        }
+                    }
+                }
+                $effectsText = ""
+                if ($effectsByPolicySet.Count -gt 0) {
+                    $effectsText = $effectsByPolicySet -join $inTableBreak
+                }
+                $complianceText = ""
+                if ($DocumentationSpecification.markdownIncludeComplianceGroupNames) {
+                    if ($groupNamesList.Count -gt 0) {
+                        $groupNamesList = $groupNamesList | Sort-Object -Unique
+                        $complianceText = $groupNamesList -join $inTableBreak
+                    }
+                }
+                $policyDisplayName = $_.displayName -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
+                $policyDescription = $_.description -replace "\n\r", " " -replace "\n", " " -replace "\r", " "
+                if ($DocumentationSpecification.markdownIncludeComplianceGroupNames) {
+                    $null = $allLines.Add("| $($_.category) | **$($policyDisplayName)**$($inTableAfterDisplayNameBreak)$($policyDescription) | $complianceText | $effectsText |")
+                }
+                else {
+                    $null = $allLines.Add("| $($_.category) | **$($policyDisplayName)**$($inTableAfterDisplayNameBreak)$($policyDescription) | $effectsText |")
+                }
+            }
+            else {
+                Write-Verbose "Skipping manual policy: $($_.name)"
+            }
+        }
+    }
+    #endregion Policy Effects One Column	
 
     #region Policy Parameters
     if ($DocumentationSpecification.markdownSuppressParameterSection) {


### PR DESCRIPTION
Added options:

- includePolicySetList : The PolicySetList may not give you any added usefull information, so now you can skip it. (Default 'true' is unchanged from previous method, parameter is optional)
- policySetEffectsOneColumn: when using a larger number of (custom) PolicySets, in ADO the .md file gets very wide, and is not very helpfull. Setting the value to 'true' you get the Effect values in one column. Default 'false' is unchanged from previous method, parameter is optional)