### PR TITLE
Get-AzExemptions: Add -ExportForEpac flag to output EPAC-ready JSON

### DIFF
--- a/Docs/operational-scripts-reference.md
+++ b/Docs/operational-scripts-reference.md
@@ -271,7 +271,7 @@ Filter by Policy Effect "deployifnotexists" and "modify" and compliance status "
 Retrieves Policy Exemptions from an EPAC environment and saves them to files.
 
 ```ps1
-Get-AzExemptions [[-PacEnvironmentSelector] <String>] [-DefinitionsRootFolder <String>] [-OutputFolder <String>] [-Interactive <Boolean>] [-FileExtension <String>] [-ActiveExemptionsOnly] [<CommonParameters>]
+Get-AzExemptions [[-PacEnvironmentSelector] <String>] [-DefinitionsRootFolder <String>] [-OutputFolder <String>] [-Interactive <Boolean>] [-FileExtension <String>] [-ActiveExemptionsOnly] [-ExportForEpac] [<CommonParameters>]
 ```
 
 ### Parameters
@@ -299,6 +299,10 @@ File extension type for the output files. Valid values are json or jsonc. The de
 #### `-ActiveExemptionsOnly [<SwitchParameter>]`
 
 Set to true to only generate files for active (not expired and not orphaned) exemptions. Defaults to false.
+
+#### `-ExportForEpac [<SwitchParameter>]`
+
+Set to true to additionally write an EPAC-ready JSON file (`epac-exemptions.<FileExtension>`) into the per-environment output folder. The file contains only properties recognised by the EPAC `policyExemptions` schema — Azure-only fields such as `status` and `expiresInDays`, plus the `deployedBy` and `epacMetadata` blocks inside `metadata`, are stripped out so the output can be copied directly into the appropriate `policyExemptions` folder without manual cleanup. Combines with `-ActiveExemptionsOnly` to restrict the export to active exemptions. Defaults to false.
 
 ## Script `Get-AzMissingTags`
 

--- a/Docs/operational-scripts.md
+++ b/Docs/operational-scripts.md
@@ -36,7 +36,7 @@ This script executes all remediation tasks in a Policy as Code environment speci
 </div>
 
 * `Export-AzPolicyResources` exports Azure Policy resources in EPAC. See usage documentation in [Extract existing Policy Resources](start-extracting-policy-resources.md).
-* `Get-AzExemptions` retrieves Policy Exemptions from an EPAC environment and saves them to files.
+* `Get-AzExemptions` retrieves Policy Exemptions from an EPAC environment and saves them to files. Pass `-ExportForEpac` to additionally produce an `epac-exemptions.<ext>` file that is already stripped of Azure-only fields and can be committed directly into the EPAC repo.
 * `Get-AzPolicyAliasOutputCSV` exports Policy Aliases to CSV format.
 
 ## Hydration Kit

--- a/Docs/policy-exemptions.md
+++ b/Docs/policy-exemptions.md
@@ -40,7 +40,7 @@ Exemption_00000000000001,My display Name,Mitigated,,,,,,
 
 Exemptions can be defined as JSON or CSV files (we recommend that you use JSON files). The names of the definition files don't matter. If multiple files exist in a folder, the lists from all the files are added together.
 
-The pacEnvironment (see global-settings.jsonc) is represented with a folder structure under the folder policyExemptions, such as epac-dev, tenant, ... A missing folder indicates that the pacEnvironment's Exemptions are not managed by this solution. To extract existing exemptions, the operations script Get-AzExemptions.ps1 can be used to generate JSON and CSV files. The output may be used to start the Exemption definitions. This same output is also created when [Extract existing Policy Resources from an Environment](epac-extracting-policy-resources.md).
+The pacEnvironment (see global-settings.jsonc) is represented with a folder structure under the folder policyExemptions, such as epac-dev, tenant, ... A missing folder indicates that the pacEnvironment's Exemptions are not managed by this solution. To extract existing exemptions, the operations script Get-AzExemptions.ps1 can be used to generate JSON and CSV files. The output may be used to start the Exemption definitions. Pass `-ExportForEpac` to that script to additionally produce an `epac-exemptions.<ext>` file already stripped of Azure-only fields (e.g. `status`, `expiresInDays`, `metadata.deployedBy`, `metadata.epacMetadata`) that can be copied directly into the appropriate `policyExemptions` folder. This same output is also created when [Extract existing Policy Resources from an Environment](epac-extracting-policy-resources.md).
 
 A typical folder structure might look like this:
 

--- a/Scripts/Helpers/Out-PolicyExemptions.ps1
+++ b/Scripts/Helpers/Out-PolicyExemptions.ps1
@@ -8,7 +8,8 @@ function Out-PolicyExemptions {
         [switch] $OutputJson,
         [switch] $OutputCsv,
         [string] $FileExtension = "json",
-        [switch] $ActiveExemptionsOnly
+        [switch] $ActiveExemptionsOnly,
+        [switch] $ExportForEpac
     )
 
     $numberOfExemptions = $Exemptions.Count
@@ -374,6 +375,117 @@ function Out-PolicyExemptions {
         }
 
         #endregion All Exemptions
+
+    }
+
+    if ($ExportForEpac) {
+
+        #region EPAC-ready Exemptions Export
+
+        $epacStem = "$outputPath/epac-exemptions"
+        Write-ModernSection -Title "EPAC-ready Exemptions" -Color Cyan
+        Write-ModernStatus -Message "Environment: $pacSelector" -Status "info" -Indent 2
+
+        # Allowed top-level properties per Schemas/policy-exemption-schema.json.
+        # Built dynamically from the input so we only include properties that have meaningful values
+        # (the EPAC schema sets additionalProperties: false and also requires certain combinations).
+        $epacOptionalProperties = @(
+            "displayName",
+            "description",
+            "exemptionCategory",
+            "expiresOn",
+            "scope",
+            "policyAssignmentId",
+            "policyDefinitionReferenceIds",
+            "resourceSelectors",
+            "assignmentScopeValidation"
+        )
+
+        $epacArray = [System.Collections.Generic.List[object]]::new()
+        $epacSource = $selectedExemptions
+        if ($ActiveExemptionsOnly) {
+            $epacSource = $selectedExemptions | Where-Object status -in @("active", "active-expiring-within-15-days")
+        }
+        foreach ($exemption in $epacSource) {
+            $epacObj = [ordered]@{
+                name = $exemption.name
+            }
+            foreach ($prop in $epacOptionalProperties) {
+                $value = $exemption.$prop
+                if ($null -eq $value) {
+                    continue
+                }
+                if ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) {
+                    continue
+                }
+                if ($value -is [System.Collections.ICollection] -and $value.Count -eq 0) {
+                    continue
+                }
+                if ($prop -eq "resourceSelectors") {
+                    $rebuilt = [System.Collections.Generic.List[object]]::new()
+                    foreach ($rs in $value) {
+                        $selList = [System.Collections.Generic.List[object]]::new()
+                        foreach ($sel in $rs.selectors) {
+                            $selObj = [ordered]@{ kind = $sel.kind }
+                            if ($sel.in) {
+                                $inList = [System.Collections.Generic.List[object]]::new()
+                                foreach ($v in $sel.in) { $inList.Add($v) }
+                                $selObj["in"] = $inList
+                            }
+                            if ($sel.notIn) {
+                                $notInList = [System.Collections.Generic.List[object]]::new()
+                                foreach ($v in $sel.notIn) { $notInList.Add($v) }
+                                $selObj["notIn"] = $notInList
+                            }
+                            $selList.Add([PSCustomObject]$selObj)
+                        }
+                        $rebuilt.Add([PSCustomObject]@{
+                                name      = $rs.name
+                                selectors = $selList
+                            })
+                    }
+                    $epacObj[$prop] = $rebuilt
+                    continue
+                }
+                if ($prop -eq "policyDefinitionReferenceIds") {
+                    $refList = [System.Collections.Generic.List[object]]::new()
+                    foreach ($r in $value) { $refList.Add($r) }
+                    $epacObj[$prop] = $refList
+                    continue
+                }
+                $epacObj[$prop] = $value
+            }
+
+            # Strip Azure-only and EPAC-internal metadata; omit metadata entirely if nothing remains.
+            if ($null -ne $exemption.metadata) {
+                $cleanMetadata = Get-CustomMetadata -Metadata $exemption.metadata -Remove "pacOwnerId"
+                $cleanMetadataHash = ConvertTo-HashTable $cleanMetadata
+                foreach ($strip in @("deployedBy", "epacMetadata")) {
+                    if ($cleanMetadataHash.Keys -contains $strip) {
+                        $cleanMetadataHash.Remove($strip)
+                    }
+                }
+                if ($cleanMetadataHash.Count -gt 0) {
+                    $epacObj["metadata"] = $cleanMetadataHash
+                }
+            }
+
+            $epacArray.Add([PSCustomObject]$epacObj)
+        }
+
+        Write-ModernStatus -Message "Outputting $($epacArray.Count) EPAC-ready exemptions" -Status "success" -Indent 2
+
+        $epacFile = "$epacStem.$FileExtension"
+        if (Test-Path $epacFile) {
+            Remove-Item $epacFile
+        }
+        $epacOutputObj = [ordered]@{
+            '$schema'  = "https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-exemption-schema.json"
+            exemptions = $epacArray
+        }
+        ConvertTo-Json $epacOutputObj -Depth 100 | Out-File $epacFile -Force
+
+        #endregion EPAC-ready Exemptions Export
 
     }
 }

--- a/Scripts/Operations/Get-AzExemptions.ps1
+++ b/Scripts/Operations/Get-AzExemptions.ps1
@@ -20,6 +20,9 @@
 .PARAMETER ActiveExemptionsOnly
     Set to true to only generate files for active (not expired and not orphaned) exemptions. Defaults to false.
 
+.PARAMETER ExportForEpac
+    Set to true to additionally write an EPAC-ready JSON file ('epac-exemptions.<FileExtension>'). The file contains only properties recognised by the EPAC policyExemptions schema (strips Azure-only fields such as status, expiresInDays, and the metadata.deployedBy / metadata.epacMetadata blocks), so it can be copied directly into the appropriate policyExemptions folder without manual cleanup. Defaults to false.
+
 .EXAMPLE
     .\Get-AzExemptions.ps1 -PacEnvironmentSelector "dev" -DefinitionsRootFolder "C:\Src\Definitions" -OutputFolder "C:\Src\Outputs" -Interactive $true -FileExtension "jsonc"
     Retrieves Policy Exemptions from an EPAC environment and saves them to files.
@@ -27,6 +30,10 @@
 .EXAMPLE
     .\Get-AzExemptions.ps1 -Interactive $true
     Retrieves Policy Exemptions from an EPAC environment and saves them to files. The script prompts for the PAC environment and uses the default definitions and output folders.
+
+.EXAMPLE
+    .\Get-AzExemptions.ps1 -PacEnvironmentSelector "dev" -ExportForEpac
+    Retrieves Policy Exemptions and additionally writes an EPAC-ready JSON file that can be committed directly into the EPAC repository.
 
 .LINK
     https://azure.github.io/enterprise-azure-policy-as-code/policy-exemptions/
@@ -50,7 +57,10 @@ param(
     [string] $FileExtension = "json",
 
     [Parameter(Mandatory = $false, HelpMessage = "Set to true to only generate files for active (not expired and not orphaned) exemptions. Defaults to false.")]
-    [switch] $ActiveExemptionsOnly
+    [switch] $ActiveExemptionsOnly,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Set to true to additionally write an EPAC-ready JSON file ('epac-exemptions.<FileExtension>') with Azure-only fields removed so it can be committed directly into the EPAC repository. Defaults to false.")]
+    [switch] $ExportForEpac
 )
 
 # Dot Source Helper Scripts
@@ -86,4 +96,5 @@ Out-PolicyExemptions `
     -OutputJson `
     -OutputCsv `
     -FileExtension $FileExtension `
-    -ActiveExemptionsOnly:$ActiveExemptionsOnly
+    -ActiveExemptionsOnly:$ActiveExemptionsOnly `
+    -ExportForEpac:$ExportForEpac


### PR DESCRIPTION
Running `Get-AzExemptions` and committing its output back into an EPAC repo currently requires manual cleanup -- the exported JSON contains read-only/computed fields (`status`, `expiresInDays`, `metadata.deployedBy`, `metadata.epacMetadata`) that the EPAC exemption schema rejects (`additionalProperties: false`), plus a sprinkling of `null` optional properties that just add noise.

This adds a `-ExportForEpac` switch that writes an additional `epac-exemptions.<ext>` file alongside the existing outputs, containing only the fields the EPAC schema allows. It composes with `-ActiveExemptionsOnly` (re-filters on `active` / `active-expiring-within-15-days`) and leaves the existing default outputs unchanged so current automation is unaffected.

### Approach

- New `[switch] $ExportForEpac` on `Get-AzExemptions.ps1` is passed straight through to `Out-PolicyExemptions.ps1`, where a dedicated export branch builds a clean payload from `selectedExemptions`:
  - drops `status` and `expiresInDays`
  - strips `deployedBy` / `epacMetadata` from `metadata` and omits `metadata` entirely if it ends up empty
  - omits `null` / empty optional properties (`description`, `expiresOn`, `policyDefinitionReferenceIds`, `resourceSelectors`, `assignmentScopeValidation`)
  - preserves the original `scope` vs `scopes` shape
- All arrays are built with `[System.Collections.Generic.List[object]]` so `ConvertTo-Json` doesn't unwrap single-element arrays (the `,@(...)` trick produced nested arrays, which the schema also rejects).
- Composes with `-ActiveExemptionsOnly` by re-applying the same status filter inside the export branch.
- Docs updated in `Docs/operational-scripts.md`, `Docs/operational-scripts-reference.md`, and `Docs/policy-exemptions.md`.

### Verification

Two PowerShell smoke tests against a representative exemption set confirmed:

- Stripped fields are absent (`status`, `expiresInDays`, `metadata.deployedBy`, `metadata.epacMetadata`).
- Arrays preserve their JSON shape for single- and multi-element `policyDefinitionReferenceIds`, `resourceSelectors`, nested `selectors`, and `in` / `notIn`.
- Empty `metadata` is removed entirely; null optional properties are omitted.
- Combined `-ActiveExemptionsOnly -ExportForEpac` correctly filters by status before exporting.

Then exercised end-to-end against a populated test EPAC repo (1 custom initiative + 4 assignments + 5 deliberately-varied exemptions covering every optional field): the resulting `epac-exemptions.jsonc` passes EPAC schema validation and `Build-DeploymentPlans` round-trips it as zero changes.

### Notes for reviewers

- Scope is intentionally `Get-AzExemptions` only. `Export-AzPolicyResources` also calls `Out-PolicyExemptions` and exposes `-ExemptionFiles json`, but it doesn't fully clean either -- happy to follow up in a separate PR if that's wanted.
- No changes to default-output behavior; the new file is opt-in via the switch.

Fixes: #1278
