### PR TITLE
Fix: Skip CAF3 hierarchy test when user opts out of creating it

### DIFF
--- a/Scripts/Helpers/Test-HydrationCaf3Hierarchy.ps1
+++ b/Scripts/Helpers/Test-HydrationCaf3Hierarchy.ps1
@@ -49,20 +49,10 @@ function Test-HydrationCaf3Hierarchy {
     if ((!$TenantId) -or ($TenantId -eq "")) {
         $TenantId = (Get-AzContext).Tenant.Id
     }
-    $mgPullIncrement = 0
-    do {
-        $mgPullIncrement++
-        try {
-            $mgStructure = Get-AzManagementGroupRestMethod -GroupId $TenantId -Expand -Recurse
-        }
-        catch {
-            if ($mgPullIncrement -eq 3) {
-                Write-Error "Failed to retrieve Management Group structure after 3 attempts, exiting. Reconnect to Azure and retry test."
-            
-            }
-            Write-Warning "Failed to retrieve Management Group structure, retrying $(10-$mgPullIncrement) more times..."
-        }
-    }until($mgStructure -or $mgPullIncrement -eq 3)
+    if ((!$TenantId) -or ($TenantId -eq "")) {
+        Write-Error "TenantId is required for Test-HydrationCaf3Hierarchy."
+        return "Failed"
+    }
 
     $testResults = @{}
     try {

--- a/Scripts/HydrationKit/Install-HydrationEpac.ps1
+++ b/Scripts/HydrationKit/Install-HydrationEpac.ps1
@@ -795,31 +795,36 @@ function Install-HydrationEpac {
 
     # Test New MG Values
     
-    try {
-        $gatherData.currentTenantPacSelector.caf3Status = $environmentEntry.caf3Status = `
-            Test-HydrationCaf3Hierarchy `
-            -TenantId $(Get-AzContext).Tenant.Id `
-            -TenantIntermediateRoot $TenantIntermediateRoot `
-            -MgPrefix:$allInterviewAnswers.mainCaf3Prefix `
-            -MgSuffix:$allInterviewAnswers.mainCaf3Suffix `
-            -LogFilePath $logFilePath
+    if ($allInterviewAnswers.createMainCaf3Hierarchy -eq "Yes") {
+        try {
+            $gatherData.currentTenantPacSelector.caf3Status = $environmentEntry.caf3Status = `
+                Test-HydrationCaf3Hierarchy `
+                -TenantId $(Get-AzContext).Tenant.Id `
+                -TenantIntermediateRoot $TenantIntermediateRoot `
+                -MgPrefix:$allInterviewAnswers.mainCaf3Prefix `
+                -MgSuffix:$allInterviewAnswers.mainCaf3Suffix `
+                -LogFilePath $logFilePath
+        }
+        catch {
+            Write-Error $Error[0].Exception.Message
+            return
+        }
+        try {
+            $gatherData.currentTenantPacSelector.caf3Status = $environmentEntry.caf3Status = `
+                Test-HydrationCaf3Hierarchy `
+                -TenantId $(Get-AzContext).Tenant.Id `
+                -TenantIntermediateRoot $TenantIntermediateRoot `
+                -MgPrefix:$allInterviewAnswers.epacPrefix `
+                -MgSuffix:$allInterviewAnswers.epacSuffix `
+                -LogFilePath $logFilePath
+        }
+        catch {
+            Write-Error $Error[0].Exception.Message
+            return
+        }
     }
-    catch {
-        Write-Error $Error[0].Exception.Message
-        return
-    }
-    try {
-        $gatherData.currentTenantPacSelector.caf3Status = $environmentEntry.caf3Status = `
-            Test-HydrationCaf3Hierarchy `
-            -TenantId $(Get-AzContext).Tenant.Id `
-            -TenantIntermediateRoot $TenantIntermediateRoot `
-            -MgPrefix:$allInterviewAnswers.epacPrefix `
-            -MgSuffix:$allInterviewAnswers.epacSuffix `
-            -LogFilePath $logFilePath
-    }
-    catch {
-        Write-Error $Error[0].Exception.Message
-        return
+    else {
+        $gatherData.currentTenantPacSelector.caf3Status = $environmentEntry.caf3Status = "SkippedCaf3"
     }
     
     ################################################################################


### PR DESCRIPTION
When running the Hydration Kit and answering "No" to "Create CAF3 Hierarchy in Main Tenant", the installation would fail with `Failed to retrieve Management Group structure after X attempts, exiting`. This happened because `Test-HydrationCaf3Hierarchy` was called unconditionally regardless of the user's choice.

## Approach

- **Guard both `Test-HydrationCaf3Hierarchy` calls** in `Install-HydrationEpac.ps1` with `if ($allInterviewAnswers.createMainCaf3Hierarchy -eq "Yes")`. When the user opts out, `caf3Status` is set to `"SkippedCaf3"` instead.
- **Remove the unused tenant-root recursive MG retrieval** from `Test-HydrationCaf3Hierarchy.ps1`. The function fetched the entire management group tree via `Get-AzManagementGroupRestMethod -GroupId $TenantId -Expand -Recurse` but never used the result -- this was the actual source of the reported error. Replaced with a simple TenantId validation guard.

## Notes

The per-management-group checks later in `Test-HydrationCaf3Hierarchy` already handle 403/404 gracefully and return meaningful status values, so removing the broad tenant-root retrieval does not reduce validation coverage.

Fixes: #1350