### PR TITLE
Validate policy resource names before REST deployment

### DIFF
--- a/Scripts/Deploy/Set-AzPolicyExemptionEpac.ps1
+++ b/Scripts/Deploy/Set-AzPolicyExemptionEpac.ps1
@@ -43,6 +43,7 @@ $id = "$Scope/providers/Microsoft.Authorization/policyExemptions/$Name"
 
 $exemptionObject = [ordered]@{
     id                           = $id
+    name                         = $Name
     policyAssignmentId           = $PolicyAssignmentId
     exemptionCategory            = $ExemptionCategory
     assignmentScopeValidation    = $AssignmentScopeValidation

--- a/Scripts/Helpers/Add-HelperScripts.ps1
+++ b/Scripts/Helpers/Add-HelperScripts.ps1
@@ -115,6 +115,7 @@ $scriptRoot = Split-Path $PSScriptRoot -Parent
 . "$PSScriptRoot/Write-ErrorsFromErrorInfo.ps1"
 . "$PSScriptRoot/Write-ModernOutput.ps1"
 
+. "$PSScriptRoot/RestMethods/ConvertTo-AzPolicyRestPath.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzManagementGroupRestMethod.ps1" 
 . "$PSScriptRoot/RestMethods/Get-AzPolicyAssignmentRestMethod.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzPolicyExemptionsRestMethod.ps1"

--- a/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
@@ -159,7 +159,7 @@ function Build-AssignmentDefinitionAtLeaf {
             continue
         }
         elseif (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-            Write-Error "    Leaf Node $($nodeName): Assignment name '$name' contains invalid characters <>*%&:?.+/ or ends with a space."
+            Write-Error "    Leaf Node $($nodeName): Assignment name '$name' contains invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space."
             $hasErrors = $true
             continue
         }

--- a/Scripts/Helpers/Build-ExemptionsPlan.ps1
+++ b/Scripts/Helpers/Build-ExemptionsPlan.ps1
@@ -438,7 +438,7 @@ function Build-ExemptionsPlan {
                 }
                 else {
                     if (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-                        Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "name '$($name.Substring(0, 32))...' contains invalid characters <>*%&:?.+/ or ends with a space." -EntryNumber $entryNumber
+                        Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "name '$name' contains invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -EntryNumber $entryNumber
                     }
                     elseif ($name.Length -gt 64) {
                         Add-ErrorMessage -ErrorInfo $errorInfo -ErrorString "name too long (max 64 characters)" -EntryNumber $entryNumber
@@ -1453,5 +1453,4 @@ function Build-ExemptionsPlan {
     }
     Write-Information ""
 }
-
 

--- a/Scripts/Helpers/Build-HydrationPolicyPlan.ps1
+++ b/Scripts/Helpers/Build-HydrationPolicyPlan.ps1
@@ -92,7 +92,7 @@ function Build-HydrationPolicyPlan {
             Write-Error "Policy from file '$($file.Name)' requires a name" -ErrorAction Stop
         }
         if (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-            Write-Error "Policy from file '$($file.Name) has a name '$name' containing invalid characters <>*%&:?.+/ or ends with a space." -ErrorAction Stop
+            Write-Error "Policy from file '$($file.Name) has a name '$name' containing invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -ErrorAction Stop
         }
         if ($null -eq $displayName) {
             Write-Error "Policy '$name' from file '$($file.Name)' requires a displayName" -ErrorAction Stop

--- a/Scripts/Helpers/Build-HydrationPolicySetPlan.ps1
+++ b/Scripts/Helpers/Build-HydrationPolicySetPlan.ps1
@@ -86,7 +86,7 @@ function Build-HydrationPolicySetPlan {
             Write-Error "Policy Set from file '$($file.Name)' requires a name" -ErrorAction Stop
         }
         if (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-            Write-Error "Policy Set from file '$($file.Name) has a name '$name' containing invalid characters <>*%&:?.+/ or ends with a space." -ErrorAction Stop
+            Write-Error "Policy Set from file '$($file.Name) has a name '$name' containing invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -ErrorAction Stop
         }
         if ($null -eq $displayName) {
             Write-Error "Policy Set '$name' from file '$($file.Name)' requires a displayName" -ErrorAction Stop

--- a/Scripts/Helpers/Build-PolicyPlan.ps1
+++ b/Scripts/Helpers/Build-PolicyPlan.ps1
@@ -83,7 +83,7 @@ function Build-PolicyPlan {
             Write-Error "Policy from file '$($file.Name)' requires a name" -ErrorAction Stop
         }
         if (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-            Write-Error "Policy from file '$($file.Name) has a name '$name' containing invalid characters <>*%&:?.+/ or ends with a space." -ErrorAction Stop
+            Write-Error "Policy from file '$($file.Name) has a name '$name' containing invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -ErrorAction Stop
         }
         if ($null -eq $displayName -and $definitionProperties.mode -ne "Microsoft.Network.Data") {
             Write-Error "Policy '$name' from file '$($file.Name)' requires a displayName" -ErrorAction Stop
@@ -461,5 +461,4 @@ function Build-PolicyPlan {
     Write-ModernStatus -Message "Unchanged Policy Definitions: $($Definitions.numberUnchanged)" -Status "status" -Indent 2
     Write-Information ""
 }
-
 

--- a/Scripts/Helpers/Build-PolicySetPlan.ps1
+++ b/Scripts/Helpers/Build-PolicySetPlan.ps1
@@ -81,7 +81,7 @@ function Build-PolicySetPlan {
             Write-Error "Policy Set from file '$($file.Name)' requires a name" -ErrorAction Stop
         }
         if (-not (Confirm-ValidPolicyResourceName -Name $name)) {
-            Write-Error "Policy Set from file '$($file.Name) has a name '$name' containing invalid characters <>*%&:?.+/ or ends with a space." -ErrorAction Stop
+            Write-Error "Policy Set from file '$($file.Name) has a name '$name' containing invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -ErrorAction Stop
         }
         if ($null -eq $displayName) {
             Write-Error "Policy Set '$name' from file '$($file.Name)' requires a displayName" -ErrorAction Stop
@@ -603,5 +603,4 @@ function Build-PolicySetPlan {
     # Write-ModernCountSummary -Operation "Policy Set Definitions" -Unchanged $Definitions.numberUnchanged
     Write-Information ""
 }
-
 

--- a/Scripts/Helpers/Confirm-ValidPolicyResourceName.ps1
+++ b/Scripts/Helpers/Confirm-ValidPolicyResourceName.ps1
@@ -5,11 +5,27 @@ function Confirm-ValidPolicyResourceName {
         $Name
     )
 
-    # Test is the Name has any characters from this string of characters "<>*%&:?.+/" in it or ends with a space
-    if ($Name -match "[\<\>\*\%\&\:\?\+\/\\]" -or $Name.EndsWith(" ")) {
-        return $false
+    $invalidCharacters = @('%', '&', '\', '?', '/', '<', '>', ':', '#', '*', '+')
+    foreach ($character in $Name.ToCharArray()) {
+        if ($character -in $invalidCharacters -or [char]::IsControl($character)) {
+            return $false
+        }
     }
-    else {
-        return $true
+
+    return -not $Name.EndsWith(" ")
+}
+
+function Assert-ValidPolicyResourceName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ResourceType
+    )
+
+    if (-not (Confirm-ValidPolicyResourceName -Name $Name)) {
+        Write-Error "$ResourceType name '$Name' contains invalid characters '%, &, \, ?, /, <, >, :, #, *, +' or control characters, or ends with a space." -ErrorAction Stop
     }
 }

--- a/Scripts/Helpers/RestMethods/ConvertTo-AzPolicyRestPath.ps1
+++ b/Scripts/Helpers/RestMethods/ConvertTo-AzPolicyRestPath.ps1
@@ -1,0 +1,21 @@
+function ConvertTo-AzPolicyRestPath {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Id
+    )
+
+    $policyResourceId = [regex]::Match(
+        $Id,
+        '^(?<parent>.*/providers/Microsoft\.Authorization/(?:policyAssignments|policyExemptions)/)(?<name>[^/]+)$',
+        [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+    )
+
+    if (-not $policyResourceId.Success) {
+        return $Id
+    }
+
+    $name = [System.Uri]::UnescapeDataString($policyResourceId.Groups['name'].Value)
+    $encodedName = [System.Uri]::EscapeDataString($name)
+    return "$($policyResourceId.Groups['parent'].Value)$encodedName"
+}

--- a/Scripts/Helpers/RestMethods/Get-AzPolicyAssignmentRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Get-AzPolicyAssignmentRestMethod.ps1
@@ -6,7 +6,8 @@ function Get-AzPolicyAssignmentRestMethod {
     )
 
     # Invoke the REST API
-    $response = Invoke-AzRestMethod -Path "$($AssignmentId)?api-version=$ApiVersion" -Method GET
+    $path = ConvertTo-AzPolicyRestPath -Id $AssignmentId
+    $response = Invoke-AzRestMethod -Path "$($path)?api-version=$ApiVersion" -Method GET
 
     # Process response
     $statusCode = $response.StatusCode

--- a/Scripts/Helpers/RestMethods/Remove-AzResourceByIdRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Remove-AzResourceByIdRestMethod.ps1
@@ -9,7 +9,8 @@ function Remove-AzResourceByIdRestMethod {
     )
 
     # Invoke the REST API
-    $path = "$($Id)?api-version=$($ApiVersion)"
+    $resourcePath = ConvertTo-AzPolicyRestPath -Id $Id
+    $path = "$($resourcePath)?api-version=$($ApiVersion)"
     # Write-Information "DELETE $path"
     $response = Invoke-AzRestMethod -Path $path -Method DELETE
 

--- a/Scripts/Helpers/RestMethods/Set-AzPolicyAssignmentRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Set-AzPolicyAssignmentRestMethod.ps1
@@ -5,6 +5,8 @@ function Set-AzPolicyAssignmentRestMethod {
         $ApiVersion
     )
 
+    Assert-ValidPolicyResourceName -Name $AssignmentObj.name -ResourceType "Policy assignment"
+
     # Write log info
     $id = $AssignmentObj.id
     $displayName = $AssignmentObj.displayName
@@ -53,7 +55,8 @@ function Set-AzPolicyAssignmentRestMethod {
 
     # Invoke the REST API
     $assignmentJson = ConvertTo-Json $assignment -Depth 100 -Compress
-    $response = Invoke-AzRestMethod -Path "$($id)?api-version=$ApiVersion" -Method PUT -Payload $assignmentJson
+    $path = ConvertTo-AzPolicyRestPath -Id $id
+    $response = Invoke-AzRestMethod -Path "$($path)?api-version=$ApiVersion" -Method PUT -Payload $assignmentJson
 
     # Process response
     $statusCode = $response.StatusCode

--- a/Scripts/Helpers/RestMethods/Set-AzPolicyDefinitionRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Set-AzPolicyDefinitionRestMethod.ps1
@@ -5,6 +5,8 @@ function Set-AzPolicyDefinitionRestMethod {
         $ApiVersion
     )
 
+    Assert-ValidPolicyResourceName -Name $DefinitionObj.name -ResourceType "Policy definition"
+
     # Write log info
     $displayName = $DefinitionObj.displayName
     Write-ModernStatus -Message "Setting policy definition: $displayName" -Status "info" -Indent 2

--- a/Scripts/Helpers/RestMethods/Set-AzPolicyExemptionRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Set-AzPolicyExemptionRestMethod.ps1
@@ -9,6 +9,8 @@ function Set-AzPolicyExemptionRestMethod {
         $IdentityApiVersion = "2024-12-01-preview"
     )
 
+    Assert-ValidPolicyResourceName -Name $ExemptionObj.name -ResourceType "Policy exemption"
+
     # Detect identity-based exemption selectors. When present, auto-upgrade the
     # API version because the previously default 2022-07-01-preview does not
     # define userPrincipalId / groupPrincipalId in the Selector.kind enum.
@@ -53,7 +55,8 @@ function Set-AzPolicyExemptionRestMethod {
 
     # Invoke the REST API
     $exemptionJson = ConvertTo-Json $exemption -Depth 100 -Compress
-    $response = Invoke-AzRestMethod -Path "$($ExemptionObj.id)?api-version=$effectiveApiVersion" -Method PUT -Payload $exemptionJson
+    $path = ConvertTo-AzPolicyRestPath -Id $ExemptionObj.id
+    $response = Invoke-AzRestMethod -Path "$($path)?api-version=$effectiveApiVersion" -Method PUT -Payload $exemptionJson
 
     # Process response
     $statusCode = $response.StatusCode

--- a/Scripts/Helpers/RestMethods/Set-AzPolicySetDefinitionRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Set-AzPolicySetDefinitionRestMethod.ps1
@@ -5,6 +5,8 @@ function Set-AzPolicySetDefinitionRestMethod {
         [string] $ApiVersion
     )
 
+    Assert-ValidPolicyResourceName -Name $DefinitionObj.name -ResourceType "Policy set definition"
+
     # Write log info
     $displayName = $DefinitionObj.displayName
     Write-ModernStatus -Message "Setting policy set definition: $displayName" -Status "info" -Indent 2

--- a/Tests/Helpers/Unit/Confirm-ValidPolicyResourceName.Tests.ps1
+++ b/Tests/Helpers/Unit/Confirm-ValidPolicyResourceName.Tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/Confirm-ValidPolicyResourceName.ps1')
+}
+
+Describe 'Confirm-ValidPolicyResourceName' {
+    It 'accepts a valid policy resource name' {
+        Confirm-ValidPolicyResourceName -Name 'policy.resource_name-(1)' | Should -BeTrue
+    }
+
+    It 'rejects the invalid character <Character>' -ForEach @(
+        @{ Character = '%' }
+        @{ Character = '&' }
+        @{ Character = '\' }
+        @{ Character = '?' }
+        @{ Character = '/' }
+        @{ Character = '<' }
+        @{ Character = '>' }
+        @{ Character = ':' }
+        @{ Character = '#' }
+        @{ Character = '*' }
+        @{ Character = '+' }
+    ) {
+        Confirm-ValidPolicyResourceName -Name "policy${Character}name" | Should -BeFalse
+    }
+
+    It 'rejects control characters' {
+        Confirm-ValidPolicyResourceName -Name "policy`nname" | Should -BeFalse
+    }
+
+    It 'rejects a trailing space' {
+        Confirm-ValidPolicyResourceName -Name 'policy-name ' | Should -BeFalse
+    }
+}
+
+Describe 'Assert-ValidPolicyResourceName' {
+    It 'throws a clear error for an invalid resource name' {
+        {
+            Assert-ValidPolicyResourceName -Name 'exempt-kv-delete-#protect' -ResourceType 'Policy exemption'
+        } | Should -Throw "*Policy exemption name 'exempt-kv-delete-#protect'*#*"
+    }
+}

--- a/Tests/Helpers/Unit/PolicyRestMethods.Tests.ps1
+++ b/Tests/Helpers/Unit/PolicyRestMethods.Tests.ps1
@@ -1,0 +1,191 @@
+BeforeAll {
+    $restMethodsPath = Join-Path $PSScriptRoot '../../../Scripts/Helpers/RestMethods'
+    . (Join-Path $restMethodsPath 'ConvertTo-AzPolicyRestPath.ps1')
+    . (Join-Path $restMethodsPath 'Get-AzPolicyAssignmentRestMethod.ps1')
+    . (Join-Path $restMethodsPath 'Remove-AzResourceByIdRestMethod.ps1')
+    . (Join-Path $restMethodsPath 'Set-AzPolicyAssignmentRestMethod.ps1')
+    . (Join-Path $restMethodsPath 'Set-AzPolicyDefinitionRestMethod.ps1')
+    . (Join-Path $restMethodsPath 'Set-AzPolicyExemptionRestMethod.ps1')
+    . (Join-Path $restMethodsPath 'Set-AzPolicySetDefinitionRestMethod.ps1')
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/Confirm-ValidPolicyResourceName.ps1')
+
+    function Get-DeepCloneAsOrderedHashtable {}
+    function Remove-NullFields {}
+    function Write-ModernStatus {}
+}
+
+Describe 'ConvertTo-AzPolicyRestPath' {
+    It 'encodes reserved characters in a policy assignment name' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/CApp_NoPubIng-#5030-test'
+
+        ConvertTo-AzPolicyRestPath -Id $id |
+            Should -Be '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/CApp_NoPubIng-%235030-test'
+    }
+
+    It 'encodes a provider-level policy resource name' {
+        $id = '/providers/Microsoft.Authorization/policyAssignments/assignment-#1'
+
+        ConvertTo-AzPolicyRestPath -Id $id |
+            Should -Be '/providers/Microsoft.Authorization/policyAssignments/assignment-%231'
+    }
+
+    It 'encodes reserved characters in a policy exemption name' {
+        $id = '/providers/Microsoft.Management/managementGroups/test/providers/Microsoft.Authorization/policyExemptions/exemption?#1'
+
+        ConvertTo-AzPolicyRestPath -Id $id |
+            Should -Be '/providers/Microsoft.Management/managementGroups/test/providers/Microsoft.Authorization/policyExemptions/exemption%3F%231'
+    }
+
+    It 'does not double encode an encoded policy resource name' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment-%235030'
+
+        ConvertTo-AzPolicyRestPath -Id $id | Should -Be $id
+    }
+
+    It 'does not change other resource types' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/policy-#1'
+
+        ConvertTo-AzPolicyRestPath -Id $id | Should -Be $id
+    }
+}
+
+Describe 'Policy assignment REST paths' {
+    BeforeEach {
+        Mock Invoke-AzRestMethod {
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = '{}'
+            }
+        }
+        Mock Write-ModernStatus
+        Mock Get-DeepCloneAsOrderedHashtable { [ordered]@{} }
+    }
+
+    It 'encodes the assignment name for GET requests' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment-#1'
+
+        Get-AzPolicyAssignmentRestMethod -AssignmentId $id -ApiVersion '2025-03-01'
+
+        Should -Invoke Invoke-AzRestMethod -ParameterFilter {
+            $Path -eq "$($id.Replace('#', '%23'))?api-version=2025-03-01" -and $Method -eq 'GET'
+        }
+    }
+
+    It 'encodes the assignment name for PUT requests' {
+        $assignment = @{
+            id               = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment-#1'
+            name             = 'assignment-1'
+            displayName      = 'Assignment'
+            parameters       = @{}
+            identityRequired = $false
+        }
+
+        Set-AzPolicyAssignmentRestMethod -AssignmentObj $assignment -ApiVersion '2025-03-01'
+
+        Should -Invoke Invoke-AzRestMethod -ParameterFilter {
+            $Path -eq "$($assignment.id.Replace('#', '%23'))?api-version=2025-03-01" -and $Method -eq 'PUT'
+        }
+    }
+}
+
+Describe 'Policy exemption REST paths' {
+    BeforeEach {
+        Mock Invoke-AzRestMethod {
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = '{}'
+            }
+        }
+        Mock Remove-NullFields
+        Mock Write-ModernStatus
+    }
+
+    It 'encodes the exemption name for PUT requests' {
+        $exemption = @{
+            id    = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyExemptions/exemption-#1'
+            name  = 'exemption-1'
+            scope = '/subscriptions/00000000-0000-0000-0000-000000000000'
+        }
+
+        Set-AzPolicyExemptionRestMethod -ExemptionObj $exemption -ApiVersion '2022-07-01-preview'
+
+        Should -Invoke Invoke-AzRestMethod -ParameterFilter {
+            $Path -eq "$($exemption.id.Replace('#', '%23'))?api-version=2022-07-01-preview" -and $Method -eq 'PUT'
+        }
+    }
+}
+
+Describe 'Policy resource DELETE paths' {
+    BeforeEach {
+        Mock Invoke-AzRestMethod {
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = '{}'
+            }
+        }
+
+        Mock Write-ModernStatus
+    }
+
+    It 'encodes policy assignment names' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment-#1'
+
+        Remove-AzResourceByIdRestMethod -Id $id -ApiVersion '2025-03-01'
+
+        Should -Invoke Invoke-AzRestMethod -ParameterFilter {
+            $Path -eq "$($id.Replace('#', '%23'))?api-version=2025-03-01" -and $Method -eq 'DELETE'
+        }
+    }
+
+    Describe 'Policy REST resource name validation' {
+        BeforeEach {
+            Mock Invoke-AzRestMethod
+        }
+
+        It 'rejects an invalid policy definition name before the REST call' {
+            $definition = [pscustomobject]@{ name = 'policy#name' }
+
+            { Set-AzPolicyDefinitionRestMethod -DefinitionObj $definition -ApiVersion '2025-03-01' } |
+                Should -Throw "*Policy definition name 'policy#name'*"
+
+            Should -Invoke Invoke-AzRestMethod -Times 0
+        }
+
+        It 'rejects an invalid policy set definition name before the REST call' {
+            $definition = [pscustomobject]@{ name = 'policySet#name' }
+
+            { Set-AzPolicySetDefinitionRestMethod -DefinitionObj $definition -ApiVersion '2025-03-01' } |
+                Should -Throw "*Policy set definition name 'policySet#name'*"
+
+            Should -Invoke Invoke-AzRestMethod -Times 0
+        }
+
+        It 'rejects an invalid policy assignment name before the REST call' {
+            $assignment = [pscustomobject]@{ name = 'assignment#name' }
+
+            { Set-AzPolicyAssignmentRestMethod -AssignmentObj $assignment -ApiVersion '2025-03-01' } |
+                Should -Throw "*Policy assignment name 'assignment#name'*"
+
+            Should -Invoke Invoke-AzRestMethod -Times 0
+        }
+
+        It 'rejects an invalid policy exemption name before the REST call' {
+            $exemption = [pscustomobject]@{ name = 'exemption#name' }
+
+            { Set-AzPolicyExemptionRestMethod -ExemptionObj $exemption -ApiVersion '2022-07-01-preview' } |
+                Should -Throw "*Policy exemption name 'exemption#name'*"
+
+            Should -Invoke Invoke-AzRestMethod -Times 0
+        }
+    }
+
+    It 'encodes policy exemption names' {
+        $id = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyExemptions/exemption-#1'
+
+        Remove-AzResourceByIdRestMethod -Id $id -ApiVersion '2022-07-01-preview'
+
+        Should -Invoke Invoke-AzRestMethod -ParameterFilter {
+            $Path -eq "$($id.Replace('#', '%23'))?api-version=2022-07-01-preview" -and $Method -eq 'DELETE'
+        }
+    }
+}


### PR DESCRIPTION
Azure Policy rejects resource names containing reserved characters such as `#`, but these names previously reached REST deployment and produced misleading API-version errors or late `InvalidResourceName` responses.

This change:
- URL-encodes policy assignment and exemption name segments when constructing REST paths.
- Rejects unsupported characters and control characters early for policy definitions, policy set definitions, policy assignments, and policy exemptions.
- Applies a final validation guard in each policy REST setter and improves contextual build errors.
- Adds regression coverage for encoded paths, double-encoding prevention, and all four resource-name checks.

Fixes: #1358