### PR TITLE
Add AMBA policy set parameter file support

### DIFF
--- a/Docs/integrating-with-alz-library.md
+++ b/Docs/integrating-with-alz-library.md
@@ -148,8 +148,18 @@ For users interested in deploying the [Azure Monitor Baseline Alerts](https://az
 # Create a Pac Environment default file for AMBA policies using the latest release of the ALZ Library 
 New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev"
 
+# Also create policyStructures\amba.policy_set_parameters.jsonc with every policy set parameter and its default value.
+# Parameters that define allowed values include those values in a preceding JSONC comment.
+New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev" -GenerateParameterFile
+
 # Sync the AMBA policies and assign to the "epac-dev" PAC environment.
 Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev"
+
+# Use the generated parameter file when creating assignments. Only values that differ from policy set defaults are emitted.
+Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev" -ParameterFile .\Definitions\policyStructures\amba.policy_set_parameters.jsonc
+
+# Archetype and enforcement overrides can still be enabled; overrides.parameters is ignored when -ParameterFile is supplied.
+Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev" -ParameterFile .\Definitions\policyStructures\amba.policy_set_parameters.jsonc -EnableOverrides
 ```
 
 The Azure Monitor Baseline Alerts project also provides a number of policy definitions not included in the ALZ Library. To sync these definitions use the `-SyncAMBAExtendedPolicies` switch as below when syncing the AMBA policies. 

--- a/Docs/integrating-with-alz-library.md
+++ b/Docs/integrating-with-alz-library.md
@@ -155,7 +155,8 @@ New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions -Type AMBA -P
 # Sync the AMBA policies and assign to the "epac-dev" PAC environment.
 Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev"
 
-# Use the generated parameter file when creating assignments. Only values that differ from policy set defaults are emitted.
+# Use the generated parameter file when creating assignments. defaultParameterValues takes priority over the
+# parameter file, and only effective values that differ from policy set defaults are emitted.
 Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type AMBA -PacEnvironmentSelector "epac-dev" -ParameterFile .\Definitions\policyStructures\amba.policy_set_parameters.jsonc
 
 # Archetype and enforcement overrides can still be enabled; overrides.parameters is ignored when -ParameterFile is supplied.

--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -12,11 +12,17 @@ Param(
     [string] $Tag,
 
     [Parameter(Mandatory = $true)]
-    [string] $PacEnvironmentSelector
+    [string] $PacEnvironmentSelector,
+
+    [switch] $GenerateParameterFile
 )
 
 # Dot Source Helper Scripts
 . "$PSScriptRoot/../Helpers/Add-HelperScripts.ps1"
+
+if ($GenerateParameterFile -and $Type -ne "AMBA") {
+    throw "-GenerateParameterFile is only supported when -Type is AMBA."
+}
 
 if ($DefinitionsRootFolder -eq "") {
     if ($null -eq $env:PAC_DEFINITIONS_FOLDER) {
@@ -210,6 +216,73 @@ Write-ModernSection -Title "Writing Output Files" -Indent 0
 $outputDirectory = "$DefinitionsRootFolder\policyStructures"
 if (-not (Test-Path -Path $outputDirectory)) {
     New-Item -ItemType Directory -Path $outputDirectory
+}
+
+if ($GenerateParameterFile) {
+    $policySetDirectory = Join-Path $LibraryPath "platform\$($Type.ToLower())\policy_set_definitions"
+    if (-not (Test-Path -Path $policySetDirectory)) {
+        throw "Policy set definition directory not found: $policySetDirectory"
+    }
+
+    $policySetFiles = @(Get-ChildItem -Path $policySetDirectory -Filter "*.json" -File)
+    if ($policySetFiles.Count -eq 0) {
+        throw "No policy set definitions found in: $policySetDirectory"
+    }
+
+    $policySetsByName = @{}
+    foreach ($policySetFile in $policySetFiles) {
+        try {
+            $policySet = Get-Content -Path $policySetFile.FullName -Raw | ConvertFrom-Json
+        }
+        catch {
+            throw "Could not read policy set definition '$($policySetFile.FullName)': $($_.Exception.Message)"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($policySet.name)) {
+            throw "Policy set definition '$($policySetFile.FullName)' does not contain a name."
+        }
+        if ($policySetsByName.ContainsKey($policySet.name)) {
+            throw "Duplicate policy set name '$($policySet.name)' found in: $policySetDirectory"
+        }
+
+        $policySetsByName.Add($policySet.name, $policySet)
+    }
+
+    $policySetNames = [string[]] @($policySetsByName.Keys)
+    [Array]::Sort($policySetNames, [System.StringComparer]::Ordinal)
+
+    $parameterFileContent = [System.Text.StringBuilder]::new()
+    $null = $parameterFileContent.AppendLine("{")
+
+    for ($policySetIndex = 0; $policySetIndex -lt $policySetNames.Count; $policySetIndex++) {
+        $policySet = $policySetsByName[$policySetNames[$policySetIndex]]
+        $policySetName = ConvertTo-Json -InputObject ([string] $policySet.name) -Compress
+        $null = $parameterFileContent.AppendLine("  $policySetName`: {")
+        $parameterNames = [string[]] @($policySet.properties.parameters.PSObject.Properties.Name | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        [Array]::Sort($parameterNames, [System.StringComparer]::Ordinal)
+
+        for ($parameterIndex = 0; $parameterIndex -lt $parameterNames.Count; $parameterIndex++) {
+            $parameter = $policySet.properties.parameters.PSObject.Properties[$parameterNames[$parameterIndex]]
+            $allowedValues = $parameter.Value.PSObject.Properties["allowedValues"]
+            if ($null -ne $allowedValues) {
+                $allowedValuesJson = ConvertTo-Json -InputObject $allowedValues.Value -Depth 100 -Compress
+                $null = $parameterFileContent.AppendLine("    // allowedValues: $allowedValuesJson")
+            }
+
+            $parameterName = ConvertTo-Json -InputObject ([string] $parameter.Name) -Compress
+            $defaultValue = ConvertTo-Json -InputObject $parameter.Value.defaultValue -Depth 100 -Compress
+            $parameterSuffix = if ($parameterIndex -lt ($parameterNames.Count - 1)) { "," } else { "" }
+            $null = $parameterFileContent.AppendLine("    $parameterName`: $defaultValue$parameterSuffix")
+        }
+
+        $policySetSuffix = if ($policySetIndex -lt ($policySetNames.Count - 1)) { "," } else { "" }
+        $null = $parameterFileContent.AppendLine("  }$policySetSuffix")
+    }
+
+    $null = $parameterFileContent.AppendLine("}")
+    $parameterFilePath = Join-Path $outputDirectory "$($Type.ToLower()).policy_set_parameters.jsonc"
+    Out-File -FilePath $parameterFilePath -InputObject $parameterFileContent.ToString() -Encoding utf8 -Force
+    Write-ModernStatus -Message "Policy set parameter file: $parameterFilePath" -Status "success" -Indent 2
 }
 
 if ($PacEnvironmentSelector) {

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -898,6 +898,37 @@ try {
                         $baseTemplate.parameters.Add($inputParameter.Name, $inputParameter.Value)
                     }
                 }
+
+                foreach ($key in $structureFile.defaultParameterValues.PSObject.Properties.Name) {
+                    foreach ($defaultParameterValue in @($structureFile.defaultParameterValues.$key)) {
+                        if (@($defaultParameterValue.policy_assignment_name) -notcontains $fileContent.name) {
+                            continue
+                        }
+
+                        foreach ($parameter in @($defaultParameterValue.parameters)) {
+                            $definitionParameter = $policySetDefinitionParameters.PSObject.Properties | Where-Object { $_.Name -eq $parameter.parameter_name } | Select-Object -First 1
+                            if ($null -eq $definitionParameter) {
+                                Write-ModernStatus -Message "Default parameter '$($parameter.parameter_name)' for policy assignment '$($fileContent.name)' does not exist in policy set '$assignedPolicySetName' and will be ignored." -Status "warning" -Indent 2
+                                continue
+                            }
+
+                            if (Test-ALZParameterValueEqual -Left $parameter.value -Right $definitionParameter.Value.defaultValue) {
+                                $null = $baseTemplate.parameters.Remove($parameter.parameter_name)
+                            }
+                            else {
+                                $baseTemplate.parameters[$parameter.parameter_name] = $parameter.value
+                            }
+                        }
+                    }
+                }
+
+                $sortedParameters = [ordered]@{}
+                $parameterNames = [string[]] @($baseTemplate.parameters.Keys)
+                [Array]::Sort($parameterNames, [System.StringComparer]::Ordinal)
+                foreach ($parameterName in $parameterNames) {
+                    $sortedParameters[$parameterName] = $baseTemplate.parameters[$parameterName]
+                }
+                $baseTemplate.parameters = $sortedParameters
             }
 
             $category = $structureFile.managementGroupNameMappings.$scopeTrim.management_group_function

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -19,13 +19,18 @@ Param(
 
     [switch] $SyncAssignmentsOnly,
 
-    [switch] $SyncAMBAExtendedPolicies
+    [switch] $SyncAMBAExtendedPolicies,
 
+    [string] $ParameterFile
 
 )
 
 # Dot Source Helper Scripts
 . "$PSScriptRoot/../Helpers/Add-HelperScripts.ps1"
+
+if (-not [string]::IsNullOrWhiteSpace($ParameterFile) -and $Type -ne "AMBA") {
+    throw "-ParameterFile is only supported when -Type is AMBA."
+}
 
 # Resolves the final archetype name after the mid-pipeline renames that are applied while
 # building the archetype array. Used in both the override-population path and the archetype-build
@@ -79,6 +84,77 @@ function Get-ALZBasedOnMatchNames {
     }
 
     return $names.ToArray()
+}
+
+function Test-ALZParameterValueEqual {
+    param(
+        [AllowNull()]
+        [object] $Left,
+
+        [AllowNull()]
+        [object] $Right
+    )
+
+    if ($null -eq $Left -or $null -eq $Right) {
+        return $null -eq $Left -and $null -eq $Right
+    }
+
+    if ($Left -is [pscustomobject] -or $Right -is [pscustomobject]) {
+        if ($Left -isnot [pscustomobject] -or $Right -isnot [pscustomobject]) {
+            return $false
+        }
+
+        $leftProperties = @($Left.PSObject.Properties)
+        $rightProperties = @($Right.PSObject.Properties)
+        if ($leftProperties.Count -ne $rightProperties.Count) {
+            return $false
+        }
+
+        foreach ($leftProperty in $leftProperties) {
+            $rightProperty = $rightProperties | Where-Object { $_.Name -ceq $leftProperty.Name } | Select-Object -First 1
+            if ($null -eq $rightProperty -or -not (Test-ALZParameterValueEqual -Left $leftProperty.Value -Right $rightProperty.Value)) {
+                return $false
+            }
+        }
+        return $true
+    }
+
+    if ($Left -is [System.Collections.IDictionary] -or $Right -is [System.Collections.IDictionary]) {
+        if ($Left -isnot [System.Collections.IDictionary] -or $Right -isnot [System.Collections.IDictionary] -or $Left.Count -ne $Right.Count) {
+            return $false
+        }
+
+        foreach ($leftKey in $Left.Keys) {
+            $rightKey = @($Right.Keys) | Where-Object { "$_" -ceq "$leftKey" } | Select-Object -First 1
+            if ($null -eq $rightKey -or -not (Test-ALZParameterValueEqual -Left $Left[$leftKey] -Right $Right[$rightKey])) {
+                return $false
+            }
+        }
+        return $true
+    }
+
+    if (($Left -is [System.Collections.IEnumerable] -and $Left -isnot [string]) -or
+        ($Right -is [System.Collections.IEnumerable] -and $Right -isnot [string])) {
+        if (($Left -isnot [System.Collections.IEnumerable] -or $Left -is [string]) -or
+            ($Right -isnot [System.Collections.IEnumerable] -or $Right -is [string])) {
+            return $false
+        }
+
+        $leftItems = @($Left)
+        $rightItems = @($Right)
+        if ($leftItems.Count -ne $rightItems.Count) {
+            return $false
+        }
+
+        for ($index = 0; $index -lt $leftItems.Count; $index++) {
+            if (-not (Test-ALZParameterValueEqual -Left $leftItems[$index] -Right $rightItems[$index])) {
+                return $false
+            }
+        }
+        return $true
+    }
+
+    return [object]::Equals($Left, $Right)
 }
 
 # Latest tag values
@@ -285,6 +361,36 @@ catch {
     Write-ModernStatus -Message "Error reading the policy default structure file: $($_.Exception.Message)" -Status "error" -Indent 2
     Write-ModernStatus -Message "Please run New-ALZPolicyDefaultStructure.ps1 first" -Status "warning" -Indent 2
     exit
+}
+
+$parameterFileValues = $null
+$policySetDefinitionsByName = @{}
+$missingParameterFilePolicySets = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+if (-not [string]::IsNullOrWhiteSpace($ParameterFile)) {
+    try {
+        $resolvedParameterFile = (Resolve-Path -Path $ParameterFile -ErrorAction Stop).Path
+        $parameterFileValues = Get-Content -Path $resolvedParameterFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parameterFileValues) {
+            throw "The parameter file is empty."
+        }
+
+        foreach ($policySetFile in Get-ChildItem -Path "$LibraryPath/platform/$($Type.ToLower())/policy_set_definitions" -Recurse -File -Include *.json) {
+            $policySetDefinition = Get-Content -Path $policySetFile.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+            if ([string]::IsNullOrWhiteSpace($policySetDefinition.name)) {
+                throw "Policy set definition '$($policySetFile.FullName)' does not contain a name."
+            }
+            $policySetDefinitionsByName[$policySetDefinition.name] = $policySetDefinition
+        }
+
+        Write-ModernStatus -Message "Policy set parameter file: $resolvedParameterFile" -Status "info" -Indent 2
+        if ($EnableOverrides -and $null -ne $structureFile.overrides.parameters) {
+            Write-ModernStatus -Message "Parameter file specified: overrides.parameters will be ignored; archetype and enforcement overrides remain enabled." -Status "info" -Indent 2
+        }
+    }
+    catch {
+        Write-ModernStatus -Message "Error reading the policy set parameter file: $($_.Exception.Message)" -Status "error" -Indent 2
+        exit 1
+    }
 }
 
 # Gather existing files
@@ -521,6 +627,7 @@ try {
         foreach ($requiredAssignment in ($archetype.policy_assignments | Where-Object {
                     -not [string]::IsNullOrWhiteSpace("$_") -and ($CreateGuardrailAssignments -or ($_ -notmatch "^Enforce-(GR|Encrypt)-\w+0"))
                 })) {
+            $assignedPolicySetName = $null
             $assignmentNameOverride = $null
             if ($policyAssignmentNameOverrides.ContainsKey($archetype.name) -and $policyAssignmentNameOverrides[$archetype.name].ContainsKey($requiredAssignment)) {
                 $assignmentNameOverride = $policyAssignmentNameOverrides[$archetype.name][$requiredAssignment]
@@ -581,19 +688,31 @@ try {
             }
             elseif ($fileContent.properties.policyDefinitions) {
                 $baseTemplate.definitionEntry.Add("policySetName", $fileContent.name)
+                $assignedPolicySetName = $fileContent.name
             }
             elseif ($fileContent.properties.policyDefinitionId -match "placeholder.+policySetDefinition") {
-                $baseTemplate.definitionEntry.Add("policySetName", ($fileContent.properties.policyDefinitionId).Split("/")[ - 1])
+                $assignedPolicySetName = ($fileContent.properties.policyDefinitionId).Split("/")[ - 1]
+                $baseTemplate.definitionEntry.Add("policySetName", $assignedPolicySetName)
             }
             elseif ($fileContent.properties.policyDefinitionId -match "placeholder.+policyDefinition") {
                 $baseTemplate.definitionEntry.Add("policyName", ($fileContent.properties.policyDefinitionId).Split("/")[ - 1])
             }
             elseif ($fileContent.properties.policyDefinitionId -match "policySetDefinitions") {
                 $baseTemplate.definitionEntry.Add("policySetId", ($fileContent.properties.policyDefinitionId))
+                $assignedPolicySetName = ($fileContent.properties.policyDefinitionId).Split("/")[ - 1]
             }
             else {
                 $baseTemplate.definitionEntry.Add("policyId", ($fileContent.properties.policyDefinitionId))
             }
+
+            $parameterFilePolicySet = $null
+            if ($null -ne $parameterFileValues -and -not [string]::IsNullOrWhiteSpace($assignedPolicySetName)) {
+                $parameterFilePolicySet = $parameterFileValues.PSObject.Properties | Where-Object { $_.Name -eq $assignedPolicySetName } | Select-Object -First 1
+                if ($null -eq $parameterFilePolicySet -and $missingParameterFilePolicySets.Add($assignedPolicySetName)) {
+                    Write-ModernStatus -Message "Policy set '$assignedPolicySetName' is not present in the parameter file; library assignment parameters will be retained." -Status "warning" -Indent 2
+                }
+            }
+            $useParameterFileForAssignment = $null -ne $parameterFilePolicySet
             
             #Scope
             $scopeTrim = $archetype.name
@@ -675,7 +794,7 @@ try {
             $baseTemplate.Add("scope", $scope)
 
             # Base Parameters
-            if ($fileContent.name -ne "Deploy-Private-DNS-Zones" -and $assignmentFromDefinition -ne $true) {
+            if (-not $useParameterFileForAssignment -and $fileContent.name -ne "Deploy-Private-DNS-Zones" -and $assignmentFromDefinition -ne $true) {
                 foreach ($parameter in $fileContent.properties.parameters.psObject.Properties.Name) {
                     $baseTemplate.parameters.Add($parameter, $fileContent.properties.parameters.$parameter.value)
                 }
@@ -694,14 +813,16 @@ try {
 
             # Check for explicit parameters
             if ($fileContent.name -ne "Deploy-Private-DNS-Zones" -and -not ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web")) {
-                foreach ($key in $structureFile.defaultParameterValues.psObject.Properties.Name) {
-                    if ($structureFile.defaultParameterValues.$key.policy_assignment_name -eq $fileContent.name) {
-                        $keyName = $structureFile.defaultParameterValues.$key.parameters.parameter_name
-                        $baseTemplate.parameters.$keyName = $structureFile.defaultParameterValues.$key.parameters.value
+                if (-not $useParameterFileForAssignment) {
+                    foreach ($key in $structureFile.defaultParameterValues.psObject.Properties.Name) {
+                        if ($structureFile.defaultParameterValues.$key.policy_assignment_name -eq $fileContent.name) {
+                            $keyName = $structureFile.defaultParameterValues.$key.parameters.parameter_name
+                            $baseTemplate.parameters.$keyName = $structureFile.defaultParameterValues.$key.parameters.value
+                        }
                     }
                 }
                 # Check for override parameter values
-                if ($EnableOverrides) {
+                if ($EnableOverrides -and $null -eq $parameterFileValues) {
                     if ($structureFile.overrides.parameters.$($archetype.name)) {
                         foreach ($overrideParameters in $structureFile.overrides.parameters.$($archetype.name) | Where-Object { $_.policy_assignment_name -eq $fileContent.name }) {
                             foreach ($param in $overrideParameters.parameters) {
@@ -754,6 +875,29 @@ try {
                 $baseTemplate.Add("additionalRoleAssignments", $additionalRoleAssignments)
 
 
+            }
+
+            if ($useParameterFileForAssignment) {
+                if (-not $policySetDefinitionsByName.ContainsKey($assignedPolicySetName)) {
+                    throw "Policy set '$assignedPolicySetName' from the parameter file was not found in the ALZ Library."
+                }
+
+                $policySetDefinitionParameters = $policySetDefinitionsByName[$assignedPolicySetName].properties.parameters
+                $inputParameterNames = [string[]] @($parameterFilePolicySet.Value.PSObject.Properties.Name | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                [Array]::Sort($inputParameterNames, [System.StringComparer]::Ordinal)
+                foreach ($inputParameterName in $inputParameterNames) {
+                    $inputParameter = $parameterFilePolicySet.Value.PSObject.Properties[$inputParameterName]
+                    $definitionParameter = $policySetDefinitionParameters.PSObject.Properties | Where-Object { $_.Name -eq $inputParameter.Name } | Select-Object -First 1
+                    if ($null -eq $definitionParameter) {
+                        Write-ModernStatus -Message "Parameter '$($inputParameter.Name)' from policy set '$assignedPolicySetName' does not exist in the ALZ Library and will be ignored." -Status "warning" -Indent 2
+                        continue
+                    }
+
+                    $defaultValue = $definitionParameter.Value.defaultValue
+                    if (-not (Test-ALZParameterValueEqual -Left $inputParameter.Value -Right $defaultValue)) {
+                        $baseTemplate.parameters.Add($inputParameter.Name, $inputParameter.Value)
+                    }
+                }
             }
 
             $category = $structureFile.managementGroupNameMappings.$scopeTrim.management_group_function

--- a/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.Tests.ps1
@@ -1,0 +1,112 @@
+BeforeAll {
+    $script:NewStructureScriptPath = Join-Path $PSScriptRoot '../../../Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1'
+    $script:DefinitionsRoot = Join-Path $TestDrive 'Definitions'
+    $script:LibraryRoot = Join-Path $TestDrive 'library'
+
+    function Invoke-RestMethod {
+        [pscustomobject]@{
+            ref = @('refs/tags/platform/amba/2026.06.1')
+        }
+    }
+
+    foreach ($path in @(
+            $script:DefinitionsRoot
+            (Join-Path $script:LibraryRoot 'platform/amba/architecture_definitions')
+            (Join-Path $script:LibraryRoot 'platform/amba/policy_set_definitions')
+        )) {
+        New-Item -ItemType Directory -Path $path -Force | Out-Null
+    }
+
+    Set-Content -Path (Join-Path $script:LibraryRoot 'platform/amba/architecture_definitions/amba.alz_architecture_definition.json') -Value @'
+{
+  "management_groups": []
+}
+'@
+
+    Set-Content -Path (Join-Path $script:LibraryRoot 'platform/amba/alz_policy_default_values.json') -Value @'
+{
+  "defaults": []
+}
+'@
+
+    Set-Content -Path (Join-Path $script:LibraryRoot 'platform/amba/policy_set_definitions/Alerting-Test.alz_policy_set_definition.json') -Value @'
+{
+  "name": "Alerting-Test",
+  "properties": {
+    "parameters": {
+      "AlertSeverity": {
+        "allowedValues": [
+          0,
+          1,
+          2
+        ],
+        "defaultValue": 2,
+        "type": "Integer"
+      },
+      "AlertEnabled": {
+        "defaultValue": true,
+        "type": "Boolean"
+      },
+      "ResourceTypes": {
+        "defaultValue": [
+          "Microsoft.Compute/virtualMachines"
+        ],
+        "type": "Array"
+      },
+      "RequiredValue": {
+        "type": "String"
+      }
+    }
+  }
+}
+'@
+
+    Set-Content -Path (Join-Path $script:LibraryRoot 'platform/amba/policy_set_definitions/00-Zeta.alz_policy_set_definition.json') -Value @'
+{
+  "name": "Zeta-Policy-Set",
+  "properties": {
+    "parameters": {}
+  }
+}
+'@
+}
+
+AfterAll {
+    Remove-Item function:Invoke-RestMethod -ErrorAction SilentlyContinue
+}
+
+Describe 'New-ALZPolicyDefaultStructure parameter file generation' {
+    It 'writes policy set parameter defaults and allowed value comments to JSONC' {
+        & $script:NewStructureScriptPath `
+            -DefinitionsRootFolder $script:DefinitionsRoot `
+            -LibraryPath $script:LibraryRoot `
+            -Type AMBA `
+            -PacEnvironmentSelector 'epac-dev' `
+            -GenerateParameterFile
+
+        $parameterFile = Join-Path $script:DefinitionsRoot 'policyStructures/amba.policy_set_parameters.jsonc'
+        Test-Path $parameterFile | Should -BeTrue
+
+        $rawContent = Get-Content -Path $parameterFile -Raw
+        $rawContent | Should -Match '// allowedValues: \[0,1,2\]\r?\n    "AlertSeverity": 2'
+        $rawContent | Should -Match '"AlertEnabled": true,\r?\n    // allowedValues: \[0,1,2\]'
+        $rawContent.IndexOf('"Alerting-Test"') | Should -BeLessThan $rawContent.IndexOf('"Zeta-Policy-Set"')
+
+        $parameters = $rawContent | ConvertFrom-Json
+        $parameters.'Alerting-Test'.AlertSeverity | Should -Be 2
+        $parameters.'Alerting-Test'.AlertEnabled | Should -BeTrue
+        $parameters.'Alerting-Test'.ResourceTypes | Should -Be @('Microsoft.Compute/virtualMachines')
+        $parameters.'Alerting-Test'.PSObject.Properties['RequiredValue'].Value | Should -BeNullOrEmpty
+    }
+
+    It 'rejects parameter file generation for non-AMBA library types' {
+        {
+            & $script:NewStructureScriptPath `
+                -DefinitionsRootFolder $script:DefinitionsRoot `
+                -LibraryPath $script:LibraryRoot `
+                -Type ALZ `
+                -PacEnvironmentSelector 'epac-dev' `
+                -GenerateParameterFile
+        } | Should -Throw '-GenerateParameterFile is only supported when -Type is AMBA.'
+    }
+}

--- a/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.ParameterFile.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.ParameterFile.Tests.ps1
@@ -1,0 +1,250 @@
+BeforeAll {
+    $script:SyncScriptPath = Join-Path $PSScriptRoot '../../../Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1'
+    $script:Tag = 'platform/amba/2026.06.1'
+
+    function New-ParameterFileTestEnvironment {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Root
+        )
+
+        $definitionsRoot = Join-Path $Root 'Definitions'
+        $libraryRoot = Join-Path $Root 'library'
+
+        foreach ($path in @(
+                $definitionsRoot
+                (Join-Path $definitionsRoot 'policyStructures')
+                (Join-Path $definitionsRoot 'policyAssignments')
+                (Join-Path $libraryRoot 'platform/amba/archetype_definitions')
+                (Join-Path $libraryRoot 'platform/amba/policy_assignments')
+                (Join-Path $libraryRoot 'platform/amba/policy_definitions')
+                (Join-Path $libraryRoot 'platform/amba/policy_set_definitions')
+            )) {
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+        }
+
+        Set-Content -Path (Join-Path $definitionsRoot 'global-settings.jsonc') -Value @'
+{
+  "telemetryOptOut": true,
+  "pacEnvironments": ["epac-dev"]
+}
+'@
+
+        Set-Content -Path (Join-Path $definitionsRoot 'policyStructures/amba.policy_default_structure.epac-dev.jsonc') -Value @'
+{
+  "enforcementMode": "Default",
+  "managementGroupNameMappings": {
+    "alz": {
+      "management_group_function": "Intermediate Root",
+      "value": "/providers/Microsoft.Management/managementGroups/alz"
+    }
+  },
+  "defaultParameterValues": {
+    "changed_parameter": [
+      {
+        "policy_assignment_name": "Deploy-Test",
+        "parameters": {
+          "parameter_name": "ChangedParameter",
+          "value": "structure-default"
+        }
+      }
+    ]
+  },
+  "overrides": {
+    "archetypes": {
+      "ignore": [],
+      "custom": [
+        {
+          "name": "alz",
+          "type": "existing",
+          "policy_assignments_to_add": [
+            {
+              "policy_name": "Deploy-Test",
+              "assignment_name": "Deploy-Test-Short"
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "root": [
+        {
+          "policy_assignment_name": "Deploy-Test",
+          "parameters": [
+            {
+              "parameter_name": "ChangedParameter",
+              "value": "structure-override"
+            }
+          ]
+        }
+      ]
+    },
+    "enforcementMode": {}
+  }
+}
+'@
+
+        Set-Content -Path (Join-Path $definitionsRoot 'policyStructures/amba.policy_set_parameters.jsonc') -Value @'
+{
+  "Test-Policy-Set": {
+    "ArrayParameter": [
+      "one",
+      "two"
+    ],
+    "ChangedParameter": "custom",
+    "NoDefaultParameter": "provided",
+    "ObjectParameter": {
+      "second": 2,
+      "first": 1
+    },
+    "SameParameter": "default"
+  }
+}
+'@
+
+        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/archetype_definitions/root.alz_archetype_definition.json') -Value @'
+{
+  "name": "root",
+  "policy_assignments": [
+    "Deploy-Test"
+  ]
+}
+'@
+
+        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/policy_assignments/Deploy-Test.alz_policy_assignment.json') -Value @'
+{
+  "name": "Deploy-Test",
+  "properties": {
+    "description": "Test assignment",
+    "displayName": "Test assignment",
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/Test-Policy-Set",
+    "parameters": {
+      "ChangedParameter": {
+        "value": "library-assignment"
+      },
+      "LibraryOnlyParameter": {
+        "value": "library-only"
+      },
+      "SameParameter": {
+        "value": "library-assignment"
+      }
+    }
+  }
+}
+'@
+
+        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/policy_set_definitions/Test-Policy-Set.alz_policy_set_definition.json') -Value @'
+{
+  "name": "Test-Policy-Set",
+  "properties": {
+    "parameters": {
+      "ArrayParameter": {
+        "defaultValue": [
+          "one",
+          "two"
+        ],
+        "type": "Array"
+      },
+      "ChangedParameter": {
+        "defaultValue": "default",
+        "type": "String"
+      },
+      "NoDefaultParameter": {
+        "type": "String"
+      },
+      "ObjectParameter": {
+        "defaultValue": {
+          "first": 1,
+          "second": 2
+        },
+        "type": "Object"
+      },
+      "SameParameter": {
+        "defaultValue": "default",
+        "type": "String"
+      }
+    }
+  }
+}
+'@
+
+        [pscustomobject]@{
+            DefinitionsRoot = $definitionsRoot
+            LibraryRoot     = $libraryRoot
+            ParameterFile   = Join-Path $definitionsRoot 'policyStructures/amba.policy_set_parameters.jsonc'
+        }
+    }
+
+    function Invoke-ParameterFileSync {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Root,
+
+            [Parameter(Mandatory = $true)]
+            [pscustomobject] $Environment,
+
+            [switch] $EnableOverrides
+        )
+
+        $helperScriptPath = Join-Path $Root 'run-sync.ps1'
+        $overrideSwitch = if ($EnableOverrides) { ' -EnableOverrides' } else { '' }
+        Set-Content -Path $helperScriptPath -Value @"
+function Invoke-RestMethod {
+    [pscustomobject]@{ ref = @('refs/tags/$($script:Tag)') }
+}
+
+& '$($script:SyncScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($Environment.DefinitionsRoot.Replace("'", "''"))' -LibraryPath '$($Environment.LibraryRoot.Replace("'", "''"))' -Type AMBA -PacEnvironmentSelector 'epac-dev' -Tag '$($script:Tag)' -SyncAssignmentsOnly -ParameterFile '$($Environment.ParameterFile.Replace("'", "''"))'$overrideSwitch
+"@
+
+        & pwsh -NoLogo -NoProfile -File $helperScriptPath | Out-Null
+        $LASTEXITCODE | Should -Be 0
+    }
+}
+
+Describe 'Sync-ALZPolicyFromLibrary parameter file input' {
+    It 'emits only parameter values that differ from policy set defaults without overrides enabled' {
+        $root = Join-Path $TestDrive 'WithoutOverrides'
+        $environment = New-ParameterFileTestEnvironment -Root $root
+
+        Invoke-ParameterFileSync -Root $root -Environment $environment
+
+        $assignmentFile = Join-Path $environment.DefinitionsRoot 'policyAssignments/AMBA/epac-dev/Intermediate Root/Deploy-Test.jsonc'
+        $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
+        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'NoDefaultParameter')
+        $assignment.parameters.ChangedParameter | Should -Be 'custom'
+        $assignment.parameters.NoDefaultParameter | Should -Be 'provided'
+    }
+
+    It 'ignores parameter overrides while still applying archetype overrides' {
+        $root = Join-Path $TestDrive 'WithOverrides'
+        $environment = New-ParameterFileTestEnvironment -Root $root
+
+        Invoke-ParameterFileSync -Root $root -Environment $environment -EnableOverrides
+
+        $assignmentFile = Join-Path $environment.DefinitionsRoot 'policyAssignments/AMBA/epac-dev/Intermediate Root/Deploy-Test-Short.jsonc'
+        Test-Path $assignmentFile | Should -BeTrue
+
+        $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
+        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'NoDefaultParameter')
+        $assignment.parameters.ChangedParameter | Should -Be 'custom'
+    }
+
+    It 'rejects parameter files for non-AMBA library types' {
+        $root = Join-Path $TestDrive 'UnsupportedType'
+        $environment = New-ParameterFileTestEnvironment -Root $root
+        $helperScriptPath = Join-Path $root 'run-unsupported-sync.ps1'
+
+        Set-Content -Path $helperScriptPath -Value @"
+function Invoke-RestMethod {
+    [pscustomobject]@{ ref = @('refs/tags/$($script:Tag)') }
+}
+
+& '$($script:SyncScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($environment.DefinitionsRoot.Replace("'", "''"))' -LibraryPath '$($environment.LibraryRoot.Replace("'", "''"))' -Type ALZ -PacEnvironmentSelector 'epac-dev' -Tag '$($script:Tag)' -SyncAssignmentsOnly -ParameterFile '$($environment.ParameterFile.Replace("'", "''"))'
+"@
+
+        $output = & pwsh -NoLogo -NoProfile -File $helperScriptPath 2>&1 | Out-String
+
+        $LASTEXITCODE | Should -Not -Be 0
+        $output | Should -Match '\-ParameterFile is only supported when \-Type is AMBA\.'
+    }
+}

--- a/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.ParameterFile.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.ParameterFile.Tests.ps1
@@ -48,6 +48,24 @@ BeforeAll {
           "value": "structure-default"
         }
       }
+    ],
+    "default_only_parameter": [
+      {
+        "policy_assignment_name": "Deploy-Test",
+        "parameters": {
+          "parameter_name": "DefaultOnlyParameter",
+          "value": "structure-only"
+        }
+      }
+    ],
+    "same_parameter": [
+      {
+        "policy_assignment_name": "Deploy-Test",
+        "parameters": {
+          "parameter_name": "SameParameter",
+          "value": "default"
+        }
+      }
     ]
   },
   "overrides": {
@@ -149,6 +167,10 @@ BeforeAll {
         "defaultValue": "default",
         "type": "String"
       },
+      "DefaultOnlyParameter": {
+        "defaultValue": "default",
+        "type": "String"
+      },
       "NoDefaultParameter": {
         "type": "String"
       },
@@ -202,7 +224,7 @@ function Invoke-RestMethod {
 }
 
 Describe 'Sync-ALZPolicyFromLibrary parameter file input' {
-    It 'emits only parameter values that differ from policy set defaults without overrides enabled' {
+    It 'applies defaultParameterValues over the parameter file and emits only non-default values' {
         $root = Join-Path $TestDrive 'WithoutOverrides'
         $environment = New-ParameterFileTestEnvironment -Root $root
 
@@ -210,8 +232,9 @@ Describe 'Sync-ALZPolicyFromLibrary parameter file input' {
 
         $assignmentFile = Join-Path $environment.DefinitionsRoot 'policyAssignments/AMBA/epac-dev/Intermediate Root/Deploy-Test.jsonc'
         $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
-        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'NoDefaultParameter')
-        $assignment.parameters.ChangedParameter | Should -Be 'custom'
+        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'DefaultOnlyParameter', 'NoDefaultParameter')
+        $assignment.parameters.ChangedParameter | Should -Be 'structure-default'
+        $assignment.parameters.DefaultOnlyParameter | Should -Be 'structure-only'
         $assignment.parameters.NoDefaultParameter | Should -Be 'provided'
     }
 
@@ -225,8 +248,8 @@ Describe 'Sync-ALZPolicyFromLibrary parameter file input' {
         Test-Path $assignmentFile | Should -BeTrue
 
         $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
-        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'NoDefaultParameter')
-        $assignment.parameters.ChangedParameter | Should -Be 'custom'
+        @($assignment.parameters.PSObject.Properties.Name) | Should -Be @('ChangedParameter', 'DefaultOnlyParameter', 'NoDefaultParameter')
+        $assignment.parameters.ChangedParameter | Should -Be 'structure-default'
     }
 
     It 'rejects parameter files for non-AMBA library types' {


### PR DESCRIPTION
AMBA policy sets expose more than a thousand tunable parameters, but maintaining those values through structure-file overrides is difficult and generated assignments are overwritten during sync. This change adds a stable, editable parameter-file workflow while keeping generated assignments minimal.

## Changes

- Adds `-GenerateParameterFile` to `New-ALZPolicyDefaultStructure` for AMBA, producing an ordinally sorted JSONC file grouped by policy set with default values and `allowedValues` comments.
- Adds `-ParameterFile` to `Sync-ALZPolicyFromLibrary` for AMBA. Effective values equal to policy set defaults are omitted from assignments; only changed values are emitted.
- Applies `defaultParameterValues` after parameter-file values, so structure defaults take priority even when they are absent from the parameter file.
- Ignores `overrides.parameters` when a parameter file is supplied, while preserving archetype and enforcement overrides under `-EnableOverrides`.
- Rejects both parameter-file switches for non-AMBA library types and documents the workflow.
- Adds network-independent Pester coverage for generation, comparison, precedence, deterministic ordering, and AMBA-only validation.

## Tests

- `Invoke-Pester -Path .\Tests\CloudAdoptionFramework -Output Detailed`
- 13 tests passed.

Fixes: #1357