### PR TITLE
Fix AMBA defaults and update library tags

### DIFF
--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -42,7 +42,7 @@ if ($Tag -eq "") {
             $Tag = "platform/fsi/2025.03.0"
         }
         'AMBA' {
-            $Tag = "platform/amba/2026.06.1"
+            $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
             $Tag = "platform/slz/2026.04.2"

--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -45,7 +45,7 @@ if ($Tag -eq "") {
             $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
-            $Tag = "platform/slz/2026.04.2"
+            $Tag = "platform/slz/2026.04.3"
         }
     }
 }

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -693,7 +693,7 @@ try {
 
 
             # Check for explicit parameters
-            if ($fileContent.name -ne "Deploy-Private-DNS-Zones" -and -not ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web")) {
+            if ($fileContent.name -ne "Deploy-Private-DNS-Zones") {
                 foreach ($key in $structureFile.defaultParameterValues.psObject.Properties.Name) {
                     if ($structureFile.defaultParameterValues.$key.policy_assignment_name -eq $fileContent.name) {
                         $keyName = $structureFile.defaultParameterValues.$key.parameters.parameter_name
@@ -718,20 +718,19 @@ try {
 
                     }
                 }
-            }
-            elseif ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web") {
-                # Get the management group scope
-                $managementScopeValue = $structureFile.managementGroupNameMappings.management.value
 
-                $additionalRoleAssignments = @{
-                    $PacEnvironmentSelector = @(
-                        [ordered]@{
-                            roleDefinitionId = "/providers/microsoft.authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830"
-                            scope            = $managementScopeValue
-                        }
-                    )
+                if ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web") {
+                    $managementScopeValue = $structureFile.managementGroupNameMappings.management.value
+                    $additionalRoleAssignments = @{
+                        $PacEnvironmentSelector = @(
+                            [ordered]@{
+                                roleDefinitionId = "/providers/microsoft.authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830"
+                                scope            = $managementScopeValue
+                            }
+                        )
+                    }
+                    $baseTemplate.Add("additionalRoleAssignments", $additionalRoleAssignments)
                 }
-                $baseTemplate.Add("additionalRoleAssignments", $additionalRoleAssignments)
             }
             else {
                 $dnsZoneRegion = $structureFile.defaultParameterValues.private_dns_zone_region.parameters.value

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -91,7 +91,7 @@ if ($Tag -eq "") {
             $Tag = "platform/fsi/2025.03.0"
         }
         'AMBA' {
-            $Tag = "platform/amba/2026.06.1"
+            $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
             $Tag = "platform/slz/2026.04.2"

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -94,7 +94,7 @@ if ($Tag -eq "") {
             $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
-            $Tag = "platform/slz/2026.04.2"
+            $Tag = "platform/slz/2026.04.3"
         }
     }
 }

--- a/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.AMBAWebDefaults.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.AMBAWebDefaults.Tests.ps1
@@ -1,0 +1,102 @@
+BeforeAll {
+    $script:SyncScriptPath = Join-Path $PSScriptRoot '../../../Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1'
+    $script:Tag = 'platform/amba/2026.06.2'
+}
+
+Describe 'Sync-ALZPolicyFromLibrary AMBA Web defaults' {
+    It 'applies shared structure values while retaining the additional role assignment' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions'
+        $libraryRoot = Join-Path $TestDrive 'library'
+
+        foreach ($path in @(
+                $definitionsRoot
+                (Join-Path $definitionsRoot 'policyStructures')
+                (Join-Path $definitionsRoot 'policyAssignments')
+                (Join-Path $libraryRoot 'platform/amba/archetype_definitions')
+                (Join-Path $libraryRoot 'platform/amba/policy_assignments')
+            )) {
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+        }
+
+        Set-Content -Path (Join-Path $definitionsRoot 'global-settings.jsonc') -Value @'
+{
+  "telemetryOptOut": true,
+  "pacEnvironments": ["epac-dev"]
+}
+'@
+
+        Set-Content -Path (Join-Path $definitionsRoot 'policyStructures/amba.policy_default_structure.epac-dev.jsonc') -Value @'
+{
+  "enforcementMode": "Default",
+  "managementGroupNameMappings": {
+    "landingzones": {
+      "management_group_function": "Landing Zones",
+      "value": "/providers/Microsoft.Management/managementGroups/landingzones"
+    },
+    "management": {
+      "management_group_function": "Management",
+      "value": "/providers/Microsoft.Management/managementGroups/management"
+    }
+  },
+  "defaultParameterValues": {
+    "amba_alz_resource_group_name": [
+      {
+        "policy_assignment_name": ["Deploy-AMBA-Web"],
+        "parameters": {
+          "parameter_name": "ALZMonitorResourceGroupName",
+          "value": "rg-from-structure"
+        }
+      }
+    ]
+  }
+}
+'@
+
+        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/archetype_definitions/amba_landing_zones.alz_archetype_definition.json') -Value @'
+{
+  "name": "amba_landing_zones",
+  "policy_assignments": ["Deploy-AMBA-Web"]
+}
+'@
+
+        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/policy_assignments/Deploy-AMBA-Web.alz_policy_assignment.json') -Value @'
+{
+  "name": "Deploy-AMBA-Web",
+  "properties": {
+    "displayName": "Deploy AMBA Web",
+    "description": "Test AMBA Web assignment",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/Deploy-AMBA-Web",
+    "parameters": {
+      "ALZMonitorResourceGroupName": {
+        "value": "rg-from-library"
+      }
+    }
+  }
+}
+'@
+
+        $helperScriptPath = Join-Path $TestDrive 'run-sync.ps1'
+        Set-Content -Path $helperScriptPath -Value @"
+function Invoke-RestMethod {
+    param([string] `$Uri)
+
+    [pscustomobject]@{
+        ref = @('refs/tags/$($script:Tag)')
+    }
+}
+
+& '$($script:SyncScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($definitionsRoot.Replace("'", "''"))' -LibraryPath '$($libraryRoot.Replace("'", "''"))' -Type AMBA -PacEnvironmentSelector 'epac-dev' -Tag '$($script:Tag)' -SyncAssignmentsOnly
+"@
+
+        & pwsh -NoLogo -NoProfile -File $helperScriptPath | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        $assignmentFile = Join-Path $definitionsRoot 'policyAssignments/AMBA/epac-dev/Landing Zones/Deploy-AMBA-Web.jsonc'
+        Test-Path $assignmentFile | Should -BeTrue
+
+        $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
+        $assignment.parameters.ALZMonitorResourceGroupName | Should -Be 'rg-from-structure'
+        $assignment.additionalRoleAssignments.'epac-dev'[0].scope | Should -Be '/providers/Microsoft.Management/managementGroups/management'
+        $assignment.additionalRoleAssignments.'epac-dev'[0].roleDefinitionId | Should -Be '/providers/microsoft.authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
+    }
+}


### PR DESCRIPTION
AMBA Web assignments were bypassing the normal shared-default and override processing when their special Management Reader role assignment was added. In addition, AMBA 2026.06.1 omits `Deploy-AMBA-VMSS` from its shared policy default metadata.

This change:

- Keeps `Deploy-AMBA-Web` on the normal parameter propagation path while retaining its required additional role assignment.
- Adds regression coverage proving a structure value reaches the generated Web assignment and the role assignment remains intact.
- Updates the default AMBA tag to `2026.06.2`, which contains the upstream VMSS metadata fix.
- Updates the default SLZ tag to `2026.04.3`.

Fixes: #1360