### PR TITLE
Allow assignment parameterFile paths outside policyAssignments

### DIFF
--- a/Docs/policy-assignments-csv-parameters.md
+++ b/Docs/policy-assignments-csv-parameters.md
@@ -38,6 +38,18 @@ EPAC will find the effect parameter name for each Policy in each Policy Set and 
 
 After building the spreadsheet, you must reference the CSV file and the column prefix in each tree branch. `parameterFile` must occur once per tree branch. Define it adjacent to the `'definitionEntry` or `definitionEntryList` to improve readability.
 
+`parameterFile` accepts either a discovered CSV filename, a path relative to the assignment JSON file, or an absolute path. This allows parameter files to live outside the `policyAssignments` tree while keeping the existing filename-based behavior for in-tree CSVs.
+
+Examples:
+
+```json
+"parameterFile": "security-baseline-parameters.csv",
+"parameterFile": "../../parameters/epac-prod/security-baseline-parameters.csv",
+"parameterFile": "/mnt/shared/epac/parameters/security-baseline-parameters.csv"
+```
+
+Relative paths are resolved from the directory containing the assignment JSON file. Absolute paths are used as-is. The classic bare filename lookup is still supported when the CSV is discovered under the assignments root.
+
 ```json
 "parameterFile": "security-baseline-parameters.csv",
 "definitionEntryList": [

--- a/Schemas/policy-assignment-schema.json
+++ b/Schemas/policy-assignment-schema.json
@@ -246,7 +246,8 @@
             }
         },
         "parameterFile": {
-            "type": "string"
+            "type": "string",
+            "description": "CSV parameter file path. Accepts a discovered filename, a path relative to the assignment file, or an absolute file path."
         },
         "parameterSelector": {
             "type": "string"

--- a/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
@@ -1,9 +1,52 @@
+function Resolve-ParameterFilePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $ParameterFilePath,
+        [string] $AssignmentFilePath,
+        [hashtable] $AvailableParameterFilesCsv
+    )
+
+    $trimmedPath = $ParameterFilePath.Trim()
+    if ([string]::IsNullOrWhiteSpace($trimmedPath)) {
+        return $null
+    }
+
+    if ($null -ne $AvailableParameterFilesCsv -and $AvailableParameterFilesCsv.ContainsKey($trimmedPath)) {
+        return $AvailableParameterFilesCsv[$trimmedPath]
+    }
+
+    $candidatePaths = [System.Collections.ArrayList]::new()
+    if (-not [string]::IsNullOrWhiteSpace($AssignmentFilePath)) {
+        $assignmentDirectory = Split-Path -Path $AssignmentFilePath -Parent
+        if (-not [string]::IsNullOrWhiteSpace($assignmentDirectory)) {
+            $null = $candidatePaths.Add([System.IO.Path]::GetFullPath((Join-Path -Path $assignmentDirectory -ChildPath $trimmedPath)))
+        }
+    }
+
+    if ([System.IO.Path]::IsPathRooted($trimmedPath)) {
+        $null = $candidatePaths.Add($trimmedPath)
+    }
+
+    $workingDirectoryCandidate = [System.IO.Path]::GetFullPath((Join-Path -Path (Get-Location).Path -ChildPath $trimmedPath))
+    $null = $candidatePaths.Add($workingDirectoryCandidate)
+
+    foreach ($candidatePath in $candidatePaths) {
+        if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidatePath).ProviderPath
+        }
+    }
+
+    return $null
+}
+
 function Build-AssignmentDefinitionNode {
     # Recursive Function
     param(
         [hashtable] $PacEnvironment,
         [hashtable] $ScopeTable,
         [hashtable] $ParameterFilesCsv,
+        [string] $AssignmentFilePath,
         [hashtable] $DefinitionNode, # Current node
         [hashtable] $AssignmentDefinition, # Collected values in tree branch
         [hashtable] $CombinedPolicyDetails,
@@ -214,8 +257,8 @@ function Build-AssignmentDefinitionNode {
     $deprecatedInCSV = [System.Collections.ArrayList]::new()
     if ($DefinitionNode.parameterFile) {
         $parameterFileName = $DefinitionNode.parameterFile
-        if ($ParameterFilesCsv.ContainsKey($parameterFileName)) {
-            $fullName = $ParameterFilesCsv.$parameterFileName
+        $fullName = Resolve-ParameterFilePath -ParameterFilePath $parameterFileName -AssignmentFilePath $AssignmentFilePath -AvailableParameterFilesCsv $ParameterFilesCsv
+        if ($fullName) {
             $content = Get-Content -Path $fullName -Raw -ErrorAction Stop
             $xlsArray = @() + ($content | ConvertFrom-Csv -ErrorAction Stop)
             $csvParameterArray = Get-DeepCloneAsOrderedHashtable $xlsArray

--- a/Scripts/Helpers/Build-AssignmentPlan.ps1
+++ b/Scripts/Helpers/Build-AssignmentPlan.ps1
@@ -99,6 +99,7 @@ function Build-AssignmentPlan {
             -PacEnvironment $PacEnvironment `
             -ScopeTable $ScopeTable `
             -ParameterFilesCsv $parameterFilesCsv `
+            -AssignmentFilePath $assignmentFile.FullName `
             -DefinitionNode $assignmentObject `
             -AssignmentDefinition $rootAssignmentDefinition `
             -CombinedPolicyDetails $CombinedPolicyDetails `

--- a/Scripts/Helpers/Build-HydrationAssignmentPlan.ps1
+++ b/Scripts/Helpers/Build-HydrationAssignmentPlan.ps1
@@ -107,6 +107,7 @@ function Build-HydrationAssignmentPlan {
             -PacEnvironment $PacEnvironment `
             -ScopeTable $ScopeTable `
             -ParameterFilesCsv $parameterFilesCsv `
+            -AssignmentFilePath $assignmentFile.FullName `
             -DefinitionNode $assignmentObject `
             -AssignmentDefinition $rootAssignmentDefinition `
             -CombinedPolicyDetails $CombinedPolicyDetails `


### PR DESCRIPTION
This change fixes a gap in assignment parameter resolution: `parameterFile` values were treated as bare CSV names discovered under the assignments tree, so valid paths that point to a shared parameters folder or an absolute filesystem location were rejected.

The resolver now accepts the existing discovered-name behavior as well as explicit paths from the assignment file directory, absolute paths, and paths relative to the current working directory. This keeps compatibility with current layouts while allowing repo-shared parameter files and cross-environment references.

Documentation and schema metadata were updated to describe the supported path notations and examples.

Fixes: #1364