### PR TITLE
Fix assignment JSON parameter export

### DIFF
--- a/Docs/operational-scripts-documenting-policy.md
+++ b/Docs/operational-scripts-documenting-policy.md
@@ -11,9 +11,9 @@
 
 ## Overview
 
-The Documentation feature provides reports on Policy Assignments deployed within an environment, and comparisons of Policy Assignments and Sets of Policy Set definitions for considering differences in policies and effects.  Output is generated as Markdown (`.md`), and Excel (`.csv`) files using the script [`./Scripts/Operations/Build-PolicyDocumentation`](operational-scripts-reference.md#script-build-policydocumentation) It retrieves its instruction from the JSON files in this folder; the names of the definition JSON files don't matter as the script reads any file in the folder with a `.json` or `.jsonc` extension.
+The Documentation feature provides reports on Policy Assignments deployed within an environment, and comparisons of Policy Assignments and Sets of Policy Set definitions for considering differences in policies and effects. Output is generated as Markdown (`.md`), Excel (`.csv`) files, and parameter JSON (`.jsonc`) sidecars using the script [`./Scripts/Operations/Build-PolicyDocumentation`](operational-scripts-reference.md#script-build-policydocumentation). It retrieves its instruction from the JSON files in this folder; the names of the definition JSON files don't matter as the script reads any file in the folder with a `.json` or `.jsonc` extension.
 
-* Policy Assignments: Read and process Policy Assignments which are representative of an environment category, such as prod, test, dev, and sandbox. It generates Markdown (`.md`), and Excel (`.csv`) files.
+* Policy Assignments: Read and process Policy Assignments which are representative of an environment category, such as prod, test, dev, and sandbox. It generates Markdown (`.md`), Excel (`.csv`) files, and a parameter export in JSONC (`.jsonc`) that reflects the representative assignment values for each environment category.
 * Policy Sets: Read and process Policy Sets to compare them for Policy and effect overlap. It generates Markdown (`.md`), Excel (`.csv`) files, and JSON file (`.jsonc`).
 
 ## JSON Schema
@@ -39,6 +39,7 @@ You can define shared defaults once at the top level using `globalDocumentationS
     * `markdownAddToc`, `markdownAdoWiki`, `markdownAdoWikiConfig`
     * `markdownNoEmbeddedHtml`, `markdownIncludeComplianceGroupNames`
     * `markdownSuppressParameterSection`, `markdownMaxParameterLength`
+    * `environmentColumnsInJson` (optional list of assignment environment categories to include in the generated parameter JSON sidecar; defaults to all categories)
 
 Specific entries take precedence. If a property is set in `documentAssignments.documentationSpecifications[...]` or in a `documentPolicySets[...]` item, it overrides the global value.
 
@@ -85,13 +86,17 @@ Each file must contain one or both documentation topics, [`documentAssignments`]
                 "markdownIncludeComplianceGroupNames": true,
                 "markdownSuppressParameterSection": false,
                 "markdownMaxParameterLength": 42, //default is 42
-                "markdownAdoWikiConfig": [
-                    {
-                        "adoOrganization": "MyOrganization",
-                        "adoProject": "EPAC",
-                        "adoWiki": "EPAC"
-                    }
-                ]
+               "environmentColumnsInJson": [
+                   "prod",
+                   "test"
+               ],
+               "markdownAdoWikiConfig": [
+                   {
+                       "adoOrganization": "MyOrganization",
+                       "adoProject": "EPAC",
+                       "adoWiki": "EPAC"
+                   }
+               ]
             }
         ]
     },

--- a/Docs/policy-assignments-csv-parameters.md
+++ b/Docs/policy-assignments-csv-parameters.md
@@ -5,6 +5,9 @@ Assigning single or multiple security and compliance focused Policy Sets (Initia
 
 To address the problem of reading and maintaining hundreds or thousands of JSON lines, EPAC can use the content of a spreadsheet (CSV) to create `parameters`, `overrides` and optionally `nonComplianceMessages` for a single Policy assignment `definitionEntry` or multiple Policy definitions (`definitionEntryList`).
 
+> [!NOTE]
+> EPAC also accepts JSON and JSONC parameter sidecar files for assignment definitions. When a file is a JSON/JSONC parameter source, set `"parameterFile"` to the file name and omit `parameterSelector`; the file is expected to contain a top-level `parameters` object (or a plain parameter map) that EPAC merges into the assignment.
+
 > [!TIP]
 > This approach is best for large Policy Sets such as Azure Security Benchmark, NIST 800-53, etc. Smaller Policy Sets should still be handled with JSON `parameters`, `overrides` and `nonComplianceMessages`.
 

--- a/Schemas/policy-documentation-schema.json
+++ b/Schemas/policy-documentation-schema.json
@@ -37,7 +37,13 @@
                 "markdownNoEmbeddedHtml": { "type": "boolean" },
                 "markdownIncludeComplianceGroupNames": { "type": "boolean" },
                 "markdownSuppressParameterSection": { "type": "boolean" },
-                "markdownMaxParameterLength": { "type": "integer" }
+                "markdownMaxParameterLength": { "type": "integer" },
+                "environmentColumnsInJson": {
+                    "type": "array",
+                    "minItems": 0,
+                    "items": { "type": "string" },
+                    "description": "Optional list of environment categories to include in the assignment JSON parameter export. Defaults to all categories when omitted."
+                }
             },
             "required": [ "fileNameStem", "title" ]
         }
@@ -98,6 +104,12 @@
                 },
                 "markdownMaxParameterLength": {
                     "type": "integer"
+                },
+                "environmentColumnsInJson": {
+                    "type": "array",
+                    "minItems": 0,
+                    "items": { "type": "string" },
+                    "description": "Optional list of environment categories to include in the assignment JSON parameter export. Defaults to all categories when omitted."
                 }
             }
         },

--- a/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
@@ -56,26 +56,34 @@ function Build-AssignmentDefinitionAtLeaf {
     #region Validate optional parameterFileName, parameterSelector, nonComplianceMessageColumn
 
     $useCsv = $false
+    $parameterFileType = if ($null -ne $parameterFileName) { [System.IO.Path]::GetExtension($parameterFileName).ToLowerInvariant() } else { $null }
+    $isJsonParameterFile = $parameterFileType -in @('.json','.jsonc')
     if ($null -ne $parameterFileName) {
         if (!$hasPolicySets) {
-            Write-Error "    Leaf Node $($nodeName): CSV parameterFileName ($parameterFileName) can only be applied to Policy Set(s). This tree branch ($nodeName) does not contain definitionEntries for Policy Sets."
+            Write-Error "    Leaf Node $($nodeName): parameterFileName ($parameterFileName) can only be applied to Policy Set(s). This tree branch ($nodeName) does not contain definitionEntries for Policy Sets."
             $hasErrors = $true
         }
         if ($overrides.Count -gt 0) {
-            Write-Error "    Leaf Node $($nodeName): CSV parameterFileName ($parameterFileName) usage and explicit overrides are not allowed in the same branch." -ErrorAction Continue
+            Write-Error "    Leaf Node $($nodeName): parameterFileName ($parameterFileName) usage and explicit overrides are not allowed in the same branch." -ErrorAction Continue
             $hasErrors = $true
         }
         if ($null -ne $nonComplianceMessageColumn) {
             if ($nonComplianceMessages.Count -gt 0 -or $perEntryNonComplianceMessages) {
-                Write-Error "    Leaf Node $($nodeName): CSV parameterFileName ($parameterFileName) usage of nonComplianceMessageColumn ($nonComplianceMessageColumn) and explicit nonComplianceMessages are not allowed in the same branch." -ErrorAction Continue
+                Write-Error "    Leaf Node $($nodeName): parameterFileName ($parameterFileName) usage of nonComplianceMessageColumn ($nonComplianceMessageColumn) and explicit nonComplianceMessages are not allowed in the same branch." -ErrorAction Continue
                 $hasErrors = $true
             }
         }
         if ($null -ne $parameterSelector) {
-            $useCsv = $true
+            if ($isJsonParameterFile) {
+                Write-Error "    Leaf Node $($nodeName): parameterSelector ($parameterSelector) cannot be used with a JSON parameter file ($parameterFileName)." -ErrorAction Continue
+                $hasErrors = $true
+            }
+            else {
+                $useCsv = $true
+            }
         }
-        else {
-            Write-Error "    Leaf Node $($nodeName): CSV parameterFileName ($parameterFileName) usage requires a parameterSelector (missing)." -ErrorAction Continue
+        elseif (-not $isJsonParameterFile) {
+            Write-Error "    Leaf Node $($nodeName): parameterFileName ($parameterFileName) is a CSV file and requires a parameterSelector (missing)." -ErrorAction Continue
             $hasErrors = $true
         }
     }

--- a/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
@@ -216,48 +216,78 @@ function Build-AssignmentDefinitionNode {
         $parameterFileName = $DefinitionNode.parameterFile
         if ($ParameterFilesCsv.ContainsKey($parameterFileName)) {
             $fullName = $ParameterFilesCsv.$parameterFileName
-            $content = Get-Content -Path $fullName -Raw -ErrorAction Stop
-            $xlsArray = @() + ($content | ConvertFrom-Csv -ErrorAction Stop)
-            $csvParameterArray = Get-DeepCloneAsOrderedHashtable $xlsArray
-            # Replace CSV effect with Disabled if Deprecated
-            foreach ($entry in $csvParameterArray) {
-                # If policy in csv is found to be deprecated
-                if ($DeprecatedHash.ContainsKey($entry.name)) {
-                    # For each child in the assignment
-                    foreach ($child in $DefinitionNode.children) {
-                        # If that child is using a parameterSelector with the CSV
-                        if ($child.ContainsKey('parameterSelector')) {
-                            $key = "$($child.parameterSelector)" + "Effect"
-                            # If the parameter is not set to Disabled already
-                            if ($entry.$key -ne "Disabled") {
-                                if (!$PacEnvironment.desiredState.doNotDisableDeprecatedPolicies) {
-                                    $entry.$key = 'Disabled'
+            $fileExtension = [System.IO.Path]::GetExtension($fullName)
+            $definition.parameterFileName = $parameterFileName
+
+            if ($fileExtension -ieq ".csv") {
+                $content = Get-Content -Path $fullName -Raw -ErrorAction Stop
+                $xlsArray = @() + ($content | ConvertFrom-Csv -ErrorAction Stop)
+                $csvParameterArray = Get-DeepCloneAsOrderedHashtable $xlsArray
+                # Replace CSV effect with Disabled if Deprecated
+                foreach ($entry in $csvParameterArray) {
+                    # If policy in csv is found to be deprecated
+                    if ($DeprecatedHash.ContainsKey($entry.name)) {
+                        # For each child in the assignment
+                        foreach ($child in $DefinitionNode.children) {
+                            # If that child is using a parameterSelector with the CSV
+                            if ($child.ContainsKey('parameterSelector')) {
+                                $key = "$($child.parameterSelector)" + "Effect"
+                                # If the parameter is not set to Disabled already
+                                if ($entry.$key -ne "Disabled") {
+                                    if (!$PacEnvironment.desiredState.doNotDisableDeprecatedPolicies) {
+                                        $entry.$key = 'Disabled'
+                                    }
+                                    $null = $deprecatedInCSV.Add("$($entry.displayName) ($($entry.name))")
                                 }
-                                $null = $deprecatedInCSV.Add("$($entry.displayName) ($($entry.name))")
                             }
                         }
+                        break
                     }
-                    break
+                }
+
+                $definition.csvParameterArray = $csvParameterArray
+                $definition.csvRowsValidated = $false
+                if ($csvParameterArray.Count -eq 0) {
+                    Write-Error "    Node $($nodeName): CSV parameterFile '$parameterFileName'  is empty (zero rows)."
+                    $definition.hasErrors = $true
                 }
             }
-            
-            $definition.parameterFileName = $parameterFileName
-            $definition.csvParameterArray = $csvParameterArray
-            $definition.csvRowsValidated = $false
-            if ($csvParameterArray.Count -eq 0) {
-                Write-Error "    Node $($nodeName): CSV parameterFile '$parameterFileName'  is empty (zero rows)."
+            elseif ($fileExtension -ieq ".json" -or $fileExtension -ieq ".jsonc") {
+                $jsonContent = Get-Content -Path $fullName -Raw -ErrorAction Stop
+                $jsonParameter = $jsonContent | ConvertFrom-Json -Depth 100 -AsHashtable
+                if ($null -ne $jsonParameter) {
+                    if ($jsonParameter.ContainsKey('parameters')) {
+                        $jsonParameters = $jsonParameter.parameters
+                    }
+                    else {
+                        $jsonParameters = $jsonParameter
+                    }
+
+                    if ($jsonParameters -is [System.Collections.IDictionary]) {
+                        foreach ($parameterName in $jsonParameters.Keys) {
+                            $definition.parameters[$parameterName] = Get-DeepCloneAsOrderedHashtable $jsonParameters[$parameterName]
+                        }
+                    }
+                    else {
+                        Write-Error "    Node $($nodeName): JSON parameterFile '$parameterFileName' must contain a parameters object."
+                        $definition.hasErrors = $true
+                    }
+                }
+            }
+            else {
+                Write-Error "    Node $($nodeName): parameterFile '$parameterFileName' has an unsupported extension '$fileExtension'."
                 $definition.hasErrors = $true
             }
         }
         else {
-            Write-Error "    Node $($nodeName): CSV parameterFileName '$parameterFileName'  does not exist."
+            Write-Error "    Node $($nodeName): parameterFileName '$parameterFileName' does not exist."
             $definition.hasErrors = $true
         }
     }
     #endregion process parameterFileName and parameterSelector
 
     #region validate CSV rows
-    if (!($definition.csvRowsValidated) -and $definition.hasPolicySets -and $definition.parameterFileName -and $definition.definitionEntryList) {
+    if (!($definition.csvRowsValidated) -and $definition.hasPolicySets -and $definition.parameterFileName -and $definition.definitionEntryList -and ($definition.parameterFileName -match '(?i)\.csv$')) {
 
         $csvParameterArray = $definition.csvParameterArray
         $parameterFileName = $definition.parameterFileName

--- a/Scripts/Helpers/Build-AssignmentPlan.ps1
+++ b/Scripts/Helpers/Build-AssignmentPlan.ps1
@@ -21,13 +21,94 @@ function Build-AssignmentPlan {
     $assignmentFiles = @()
     $assignmentFiles += Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.json"
     $assignmentFiles += Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.jsonc"
+    $jsonFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.json"
+    $jsoncFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.jsonc"
     $csvFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.csv"
+
+    $parameterFilesToIgnore = [System.Collections.ArrayList]::new()
+    $collectParameterFileReferences = {
+        param(
+            [Parameter(Mandatory = $false)] $Node,
+            [Parameter(Mandatory = $true)] [string] $BasePath,
+            [Parameter(Mandatory = $true)] [string] $AssignmentsRootFolder
+        )
+
+        if ($null -eq $Node) {
+            return
+        }
+
+        if ($Node -is [System.Collections.IDictionary]) {
+            foreach ($key in $Node.Keys) {
+                $value = $Node[$key]
+                if ($key -ieq 'parameterFile' -and $null -ne $value) {
+                    $parameterFileValue = [string]$value
+                    if (-not [string]::IsNullOrWhiteSpace($parameterFileValue)) {
+                        $candidatePath = $parameterFileValue
+                        if (-not [System.IO.Path]::IsPathRooted($candidatePath)) {
+                            $candidatePath = Join-Path -Path $BasePath -ChildPath $candidatePath
+                        }
+                        try {
+                            $resolvedPath = (Resolve-Path -Path $candidatePath -ErrorAction Stop).Path
+                        }
+                        catch {
+                            $resolvedPath = [System.IO.Path]::GetFullPath($candidatePath)
+                        }
+                        $rootRelativePath = [System.IO.Path]::GetRelativePath($AssignmentsRootFolder, $resolvedPath)
+                        foreach ($entry in @($resolvedPath, $rootRelativePath, (Split-Path -Leaf $resolvedPath), (Split-Path -Leaf $candidatePath))) {
+                            if (-not [string]::IsNullOrWhiteSpace($entry) -and -not $parameterFilesToIgnore.Contains($entry)) {
+                                $null = $parameterFilesToIgnore.Add($entry)
+                            }
+                        }
+                    }
+                }
+                & $collectParameterFileReferences $value $BasePath $AssignmentsRootFolder
+            }
+            return
+        }
+
+        if ($Node -is [System.Collections.IEnumerable] -and -not ($Node -is [string])) {
+            foreach ($item in $Node) {
+                & $collectParameterFileReferences $item $BasePath $AssignmentsRootFolder
+            }
+        }
+    }
+
+    foreach ($assignmentFile in $assignmentFiles) {
+        try {
+            $assignmentObject = (Get-Content -Path $assignmentFile.FullName -Raw -ErrorAction Stop) | ConvertFrom-Json -Depth 100 -AsHashtable
+            & $collectParameterFileReferences $assignmentObject (Split-Path -Parent $assignmentFile.FullName) $AssignmentsRootFolder
+        }
+        catch {
+            continue
+        }
+    }
+
+    $assignmentFiles = @(
+        $assignmentFiles | Where-Object {
+            $fullName = $_.FullName
+            $relativePath = [System.IO.Path]::GetRelativePath($AssignmentsRootFolder, $fullName)
+            foreach ($ignored in $parameterFilesToIgnore) {
+                if ($ignored -and (($ignored -eq $fullName) -or ($ignored -eq $_.Name) -or ($ignored -eq $relativePath))) {
+                    return $false
+                }
+            }
+            return $true
+        }
+    )
+
     $parameterFilesCsv = @{}
-    if ($assignmentFiles.Length -gt 0) {
-        Write-ModernStatus -Message "Found $($assignmentFiles.Length) assignment files" -Status "success" -Indent 2
-        foreach ($csvFile in $csvFiles) {
+    foreach ($jsonFile in @($jsonFiles + $jsoncFiles)) {
+        if (-not $parameterFilesCsv.ContainsKey($jsonFile.Name)) {
+            $parameterFilesCsv.Add($jsonFile.Name, $jsonFile.FullName)
+        }
+    }
+    foreach ($csvFile in $csvFiles) {
+        if (-not $parameterFilesCsv.ContainsKey($csvFile.Name)) {
             $parameterFilesCsv.Add($csvFile.Name, $csvFile.FullName)
         }
+    }
+    if ($assignmentFiles.Length -gt 0) {
+        Write-ModernStatus -Message "Found $($assignmentFiles.Length) assignment files" -Status "success" -Indent 2
     }
     else {
         Write-Warning "No Policy Assignment files found! Deleting any Policy Assignments."

--- a/Scripts/Helpers/Build-HydrationAssignmentPlan.ps1
+++ b/Scripts/Helpers/Build-HydrationAssignmentPlan.ps1
@@ -28,13 +28,94 @@ function Build-HydrationAssignmentPlan {
     $assignmentFiles = @()
     $assignmentFiles += Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.json"
     $assignmentFiles += Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.jsonc"
+    $jsonFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.json"
+    $jsoncFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.jsonc"
     $csvFiles = Get-ChildItem -Path $AssignmentsRootFolder -Recurse -File -Filter "*.csv"
+
+    $parameterFilesToIgnore = [System.Collections.ArrayList]::new()
+    $collectParameterFileReferences = {
+        param(
+            [Parameter(Mandatory = $false)] $Node,
+            [Parameter(Mandatory = $true)] [string] $BasePath,
+            [Parameter(Mandatory = $true)] [string] $AssignmentsRootFolder
+        )
+
+        if ($null -eq $Node) {
+            return
+        }
+
+        if ($Node -is [System.Collections.IDictionary]) {
+            foreach ($key in $Node.Keys) {
+                $value = $Node[$key]
+                if ($key -ieq 'parameterFile' -and $null -ne $value) {
+                    $parameterFileValue = [string]$value
+                    if (-not [string]::IsNullOrWhiteSpace($parameterFileValue)) {
+                        $candidatePath = $parameterFileValue
+                        if (-not [System.IO.Path]::IsPathRooted($candidatePath)) {
+                            $candidatePath = Join-Path -Path $BasePath -ChildPath $candidatePath
+                        }
+                        try {
+                            $resolvedPath = (Resolve-Path -Path $candidatePath -ErrorAction Stop).Path
+                        }
+                        catch {
+                            $resolvedPath = [System.IO.Path]::GetFullPath($candidatePath)
+                        }
+                        $rootRelativePath = [System.IO.Path]::GetRelativePath($AssignmentsRootFolder, $resolvedPath)
+                        foreach ($entry in @($resolvedPath, $rootRelativePath, (Split-Path -Leaf $resolvedPath), (Split-Path -Leaf $candidatePath))) {
+                            if (-not [string]::IsNullOrWhiteSpace($entry) -and -not $parameterFilesToIgnore.Contains($entry)) {
+                                $null = $parameterFilesToIgnore.Add($entry)
+                            }
+                        }
+                    }
+                }
+                & $collectParameterFileReferences $value $BasePath $AssignmentsRootFolder
+            }
+            return
+        }
+
+        if ($Node -is [System.Collections.IEnumerable] -and -not ($Node -is [string])) {
+            foreach ($item in $Node) {
+                & $collectParameterFileReferences $item $BasePath $AssignmentsRootFolder
+            }
+        }
+    }
+
+    foreach ($assignmentFile in $assignmentFiles) {
+        try {
+            $assignmentObject = (Get-Content -Path $assignmentFile.FullName -Raw -ErrorAction Stop) | ConvertFrom-Json -Depth 100 -AsHashtable
+            & $collectParameterFileReferences $assignmentObject (Split-Path -Parent $assignmentFile.FullName) $AssignmentsRootFolder
+        }
+        catch {
+            continue
+        }
+    }
+
+    $assignmentFiles = @(
+        $assignmentFiles | Where-Object {
+            $fullName = $_.FullName
+            $relativePath = [System.IO.Path]::GetRelativePath($AssignmentsRootFolder, $fullName)
+            foreach ($ignored in $parameterFilesToIgnore) {
+                if ($ignored -and (($ignored -eq $fullName) -or ($ignored -eq $_.Name) -or ($ignored -eq $relativePath))) {
+                    return $false
+                }
+            }
+            return $true
+        }
+    )
+
     $parameterFilesCsv = @{}
-    if ($assignmentFiles.Length -gt 0) {
-        Write-Information "Number of Policy Assignment files = $($assignmentFiles.Length)"
-        foreach ($csvFile in $csvFiles) {
+    foreach ($jsonFile in @($jsonFiles + $jsoncFiles)) {
+        if (-not $parameterFilesCsv.ContainsKey($jsonFile.Name)) {
+            $parameterFilesCsv.Add($jsonFile.Name, $jsonFile.FullName)
+        }
+    }
+    foreach ($csvFile in $csvFiles) {
+        if (-not $parameterFilesCsv.ContainsKey($csvFile.Name)) {
             $parameterFilesCsv.Add($csvFile.Name, $csvFile.FullName)
         }
+    }
+    if ($assignmentFiles.Length -gt 0) {
+        Write-Information "Number of Policy Assignment files = $($assignmentFiles.Length)"
     }
     else {
         Write-Warning "No Policy Assignment files found! Deleting any Policy Assignments."

--- a/Scripts/Helpers/Out-DocumentationForPolicyAssignments.ps1
+++ b/Scripts/Helpers/Out-DocumentationForPolicyAssignments.ps1
@@ -14,7 +14,12 @@ function Out-DocumentationForPolicyAssignments {
 
     [string] $fileNameStem = $DocumentationSpecification.fileNameStem
     [string[]] $environmentCategories = $DocumentationSpecification.environmentCategories
+    [string[]] $environmentColumnsInJson = $DocumentationSpecification.environmentColumnsInJson
     [string] $title = $DocumentationSpecification.title
+
+    if ($null -eq $environmentColumnsInJson -or $environmentColumnsInJson.Count -eq 0) {
+        $environmentColumnsInJson = $environmentCategories
+    }
 
     Write-ModernSection -Title "Generating Policy Assignment documentation for '$title'" -Color Green
     Write-ModernStatus -Message "File Name: $fileNameStem" -Status "info" -Indent 2
@@ -77,8 +82,10 @@ function Out-DocumentationForPolicyAssignments {
                         category               = $flatPolicyEntry.category
                         isEffectParameterized  = $isEffectParameterized
                         ordinal                = 99
+                        effectDefault          = $flatPolicyEntry.effectDefault
                         effectAllowedValues    = @{}
                         effectAllowedOverrides = $flatPolicyEntry.effectAllowedOverrides
+                        parameters             = $flatPolicyEntry.parameters
                         environmentList        = @{}
                         groupNames             = [System.Collections.ArrayList]::new()
                         policySetList          = @{}
@@ -631,7 +638,96 @@ function Out-DocumentationForPolicyAssignments {
     }
 
     #endregion csv
-    
+
+    #region Parameters JSON
+
+    $sb = [System.Text.StringBuilder]::new()
+    $null = $sb.Append("{")
+    $null = $sb.Append("`n  `"parameters`": {")
+    $selectedJsonEnvironmentCategories = @()
+    if ($environmentColumnsInJson -and $environmentColumnsInJson.Count -gt 0) {
+        $selectedJsonEnvironmentCategories = @($environmentColumnsInJson | Where-Object { $environmentCategories -contains $_ })
+    }
+    if ($selectedJsonEnvironmentCategories.Count -eq 0) {
+        $selectedJsonEnvironmentCategories = @($environmentCategories)
+    }
+
+    $flatPolicyListAcrossEnvironments.Values | Sort-Object -Property { $_.category }, { $_.displayName } | ForEach-Object -Process {
+        if ($_.isEffectParameterized -or ($_.parameters -and $_.parameters.Keys.Count -gt 0)) {
+            $referencePath = $_.referencePath
+            $displayName = $_.displayName
+            $category = $_.category
+            $environmentList = $_.environmentList
+
+            $null = $sb.Append("`n    // ")
+            $null = $sb.Append("`n    // -----------------------------------------------------------------------------------------------------------------------------")
+            $null = $sb.Append("`n    // $($category) -- $($displayName)")
+            if ($referencePath -ne "") {
+                $null = $sb.Append("`n    //     referencePath: $($referencePath)")
+            }
+            foreach ($environmentCategory in $selectedJsonEnvironmentCategories) {
+                if ($environmentList.ContainsKey($environmentCategory)) {
+                    $environmentCategoryValues = $environmentList.$environmentCategory
+                    $effectValue = $environmentCategoryValues.effectValue
+                    if ($null -eq $effectValue) {
+                        $effectValue = $_.effectDefault
+                    }
+                    $null = $sb.Append("`n    //   $($environmentCategory): $($effectValue)")
+                }
+            }
+            $null = $sb.Append("`n    // -----------------------------------------------------------------------------------------------------------------------------")
+
+            $outputParameters = [ordered]@{}
+            foreach ($parameterName in $_.parameters.Keys) {
+                $parameter = $_.parameters.$parameterName
+
+                $environmentValues = [ordered]@{}
+                foreach ($environmentCategory in $selectedJsonEnvironmentCategories) {
+                    if ($environmentList.ContainsKey($environmentCategory)) {
+                        $environmentCategoryValues = $environmentList.$environmentCategory
+                        $envParameters = $environmentCategoryValues.parameters
+                        if ($envParameters.ContainsKey($parameterName)) {
+                            $envParameter = $envParameters.$parameterName
+                            $envValue = $envParameter.value
+                            if ($null -eq $envValue) {
+                                $envValue = $envParameter.defaultValue
+                            }
+                            if ($null -ne $envValue) {
+                                $environmentValues[$environmentCategory] = $envValue
+                            }
+                        }
+                    }
+                }
+
+                if ($environmentValues.Count -eq 0) {
+                    continue
+                }
+
+                $parameterValue = $environmentValues.Values | Select-Object -First 1
+                if ($environmentValues.Count -gt 1) {
+                    $parameterValue = [ordered]@{}
+                    foreach ($key in $environmentValues.Keys) {
+                        $parameterValue[$key] = $environmentValues[$key]
+                    }
+                }
+
+                $outputParameters[$parameterName] = $parameterValue
+            }
+
+            foreach ($parameterName in $outputParameters.Keys) {
+                $parameterValue = $outputParameters[$parameterName]
+                $null = $sb.Append("`n    `"$($parameterName)`": $(ConvertTo-Json $parameterValue -Depth 100 -Compress), // '$($displayName)'")
+            }
+        }
+    }
+    $null = $sb.Append("`n  }")
+    $null = $sb.Append("`n}")
+
+    $outputFilePath = "$($OutputPath -replace '[/\\]$', '')/$($fileNameStem).jsonc"
+    $sb.ToString() | Out-File $outputFilePath -Force
+
+    #endregion Parameters JSON
+
     #region PushToWiki
     if ($WikiClonePat -or $WikiSPN) {
         Write-ModernStatus -Message "Attempting push to Azure DevOps Wiki (Policy Assignments)" -Status "info" -Indent 2

--- a/Scripts/HydrationKit/New-HydrationPolicyDocumentationSourceFile.ps1
+++ b/Scripts/HydrationKit/New-HydrationPolicyDocumentationSourceFile.ps1
@@ -132,6 +132,7 @@ function New-HydrationPolicyDocumentationSourceFile {
     Write-Information "Updating documentAssignments\documentationSpecifications section in the template with assignment information..."
     $documentationHashtable.documentAssignments.documentationSpecifications[0].fileNameStem = $FileNameStem
     $documentationHashtable.documentAssignments.documentationSpecifications[0].environmentCategories = @() # Not used in document all option as it is overridden
+    $documentationHashtable.documentAssignments.documentationSpecifications[0].environmentColumnsInJson = @()
     $documentationHashtable.documentAssignments.documentationSpecifications[0].title = $ReportTitle
     $documentationHashtable.documentAssignments.documentationSpecifications[0].markdownIncludeComplianceGroupNames = $IncludeComplianceGroupNames
     if ($SuppressParameterSection) {


### PR DESCRIPTION
## Summary

Assignment documentation now emits the same JSON/JSONC parameter sidecar behavior for policy assignments that policy sets already produce. This keeps assignment-time values in the exported JSON, including effect-based parameters such as policy effect settings, while avoiding false CSV-only validation warnings for JSON/JSONC sidecars.

The fix also keeps parameter sidecar files from being mistaken for assignment definition files during discovery, while still allowing explicit `parameterFile` values to resolve correctly.

## Notes

- Preserves merged assignment parameter values in the final JSON output.
- Keeps effect-valued parameters in the serialized assignment parameter set.
- Ignores JSON/JSONC parameter sidecars during assignment scanning unless they are explicitly referenced.
- Restricts CSV validation checks to CSV parameter files only.

## Validation

- Smoke-tested the assignment documentation flow against the real-world JSON sidecar pattern.
- Confirmed the exported assignment JSON retains both effect and non-effect parameters.
- Confirmed JSON/JSONC parameter files no longer trigger CSV-specific warnings.
Closes #1368 