### PR TITLE
Fix AMBA additional role assignments and bump ALZ/SLZ tags

### DIFF
--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -36,7 +36,7 @@ if ($DefinitionsRootFolder -eq "") {
 if ($Tag -eq "") {
     switch ($Type) {
         'ALZ' {
-            $Tag = "platform/alz/2026.04.2"
+            $Tag = "platform/alz/2026.08.0"
         }
         'FSI' {
             $Tag = "platform/fsi/2025.03.0"
@@ -45,7 +45,7 @@ if ($Tag -eq "") {
             $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
-            $Tag = "platform/slz/2026.04.3"
+            $Tag = "platform/slz/2026.08.0"
         }
     }
 }

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -85,7 +85,7 @@ function Get-ALZBasedOnMatchNames {
 if ($Tag -eq "") {
     switch ($Type) {
         'ALZ' {
-            $Tag = "platform/alz/2026.04.2"
+            $Tag = "platform/alz/2026.08.0"
         }
         'FSI' {
             $Tag = "platform/fsi/2025.03.0"
@@ -94,7 +94,7 @@ if ($Tag -eq "") {
             $Tag = "platform/amba/2026.06.2"
         }
         'SLZ' {
-            $Tag = "platform/slz/2026.04.3"
+            $Tag = "platform/slz/2026.08.0"
         }
     }
 }
@@ -674,6 +674,14 @@ try {
 
             $baseTemplate.Add("scope", $scope)
 
+            $ambaAssignmentsRequiringAdditionalRoleAssignments = @(
+                "Deploy-AMBA-Web",
+                "Deploy-AMBA-VM",
+                "Deploy-AMBA-HybridVM",
+                "Deploy-AMBA-VMSS",
+                "Deploy-AMBA-Management"
+            )
+
             # Base Parameters
             if ($fileContent.name -ne "Deploy-Private-DNS-Zones" -and $assignmentFromDefinition -ne $true) {
                 foreach ($parameter in $fileContent.properties.parameters.psObject.Properties.Name) {
@@ -719,7 +727,7 @@ try {
                     }
                 }
 
-                if ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web") {
+                if ($Type -eq "AMBA" -and $fileContent.name -in $ambaAssignmentsRequiringAdditionalRoleAssignments) {
                     $managementScopeValue = $structureFile.managementGroupNameMappings.management.value
                     $additionalRoleAssignments = @{
                         $PacEnvironmentSelector = @(
@@ -766,7 +774,7 @@ try {
                 ([PSCustomObject]$baseTemplate | Select-Object -Property "`$schema", nodeName, assignment, definitionEntry, definitionVersion, enforcementMode, parameters, nonComplianceMessages, scope, additionalRoleAssignments | ConvertTo-Json -Depth 50) -replace "\[\[", "[" | New-Item -Path "$DefinitionsRootFolder/policyAssignments/$Type/$PacEnvironmentSelector/$category" -ItemType File -Name "$effectiveAssignmentName.jsonc" -Force -ErrorAction SilentlyContinue
                 (Get-Content "$DefinitionsRootFolder/policyAssignments/$Type/$PacEnvironmentSelector/$category/$effectiveAssignmentName.jsonc") -replace "\.ne\.", ".$dnsZoneRegion." | Set-Content "$DefinitionsRootFolder/policyAssignments/$Type/$PacEnvironmentSelector/$category/$effectiveAssignmentName.jsonc"
             }
-            elseif ($Type -eq "AMBA" -and $fileContent.name -eq "Deploy-AMBA-Web") {
+            elseif ($Type -eq "AMBA" -and $fileContent.name -in $ambaAssignmentsRequiringAdditionalRoleAssignments) {
                 ([PSCustomObject]$baseTemplate | Select-Object -Property "`$schema", nodeName, assignment, definitionEntry, definitionVersion, enforcementMode, parameters, nonComplianceMessages, scope, additionalRoleAssignments | ConvertTo-Json -Depth 50) -replace "\[\[", "[" | New-Item -Path "$DefinitionsRootFolder/policyAssignments/$Type/$PacEnvironmentSelector/$category" -ItemType File -Name "$effectiveAssignmentName.jsonc" -Force -ErrorAction SilentlyContinue
             }
             else {

--- a/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.AMBAWebDefaults.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.AMBAWebDefaults.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Sync-ALZPolicyFromLibrary AMBA Web defaults' {
   "defaultParameterValues": {
     "amba_alz_resource_group_name": [
       {
-        "policy_assignment_name": ["Deploy-AMBA-Web"],
+        "policy_assignment_name": ["Deploy-AMBA-Web", "Deploy-AMBA-VM", "Deploy-AMBA-HybridVM", "Deploy-AMBA-VMSS", "Deploy-AMBA-Management"],
         "parameters": {
           "parameter_name": "ALZMonitorResourceGroupName",
           "value": "rg-from-structure"
@@ -55,48 +55,52 @@ Describe 'Sync-ALZPolicyFromLibrary AMBA Web defaults' {
         Set-Content -Path (Join-Path $libraryRoot 'platform/amba/archetype_definitions/amba_landing_zones.alz_archetype_definition.json') -Value @'
 {
   "name": "amba_landing_zones",
-  "policy_assignments": ["Deploy-AMBA-Web"]
+ "policy_assignments": ["Deploy-AMBA-Web", "Deploy-AMBA-VM", "Deploy-AMBA-HybridVM", "Deploy-AMBA-VMSS", "Deploy-AMBA-Management"]
 }
 '@
 
-        Set-Content -Path (Join-Path $libraryRoot 'platform/amba/policy_assignments/Deploy-AMBA-Web.alz_policy_assignment.json') -Value @'
+       foreach ($assignmentName in @('Deploy-AMBA-Web','Deploy-AMBA-VM','Deploy-AMBA-HybridVM','Deploy-AMBA-VMSS','Deploy-AMBA-Management')) {
+           Set-Content -Path (Join-Path $libraryRoot "platform/amba/policy_assignments/$assignmentName.alz_policy_assignment.json") -Value @"
 {
-  "name": "Deploy-AMBA-Web",
-  "properties": {
-    "displayName": "Deploy AMBA Web",
-    "description": "Test AMBA Web assignment",
-    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/Deploy-AMBA-Web",
-    "parameters": {
-      "ALZMonitorResourceGroupName": {
-        "value": "rg-from-library"
-      }
-    }
-  }
+ "name": "$assignmentName",
+ "properties": {
+   "displayName": "Deploy $assignmentName",
+   "description": "Test $assignmentName assignment",
+   "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/$assignmentName",
+   "parameters": {
+     "ALZMonitorResourceGroupName": {
+       "value": "rg-from-library"
+     }
+   }
+ }
 }
-'@
+"@
+       }
 
-        $helperScriptPath = Join-Path $TestDrive 'run-sync.ps1'
-        Set-Content -Path $helperScriptPath -Value @"
+       $helperScriptPath = Join-Path $TestDrive 'run-sync.ps1'
+       Set-Content -Path $helperScriptPath -Value @"
 function Invoke-RestMethod {
     param([string] `$Uri)
-
+ 
     [pscustomobject]@{
         ref = @('refs/tags/$($script:Tag)')
     }
 }
-
+ 
 & '$($script:SyncScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($definitionsRoot.Replace("'", "''"))' -LibraryPath '$($libraryRoot.Replace("'", "''"))' -Type AMBA -PacEnvironmentSelector 'epac-dev' -Tag '$($script:Tag)' -SyncAssignmentsOnly
 "@
 
-        & pwsh -NoLogo -NoProfile -File $helperScriptPath | Out-Null
-        $LASTEXITCODE | Should -Be 0
+       & pwsh -NoLogo -NoProfile -File $helperScriptPath | Out-Null
+       $LASTEXITCODE | Should -Be 0
 
-        $assignmentFile = Join-Path $definitionsRoot 'policyAssignments/AMBA/epac-dev/Landing Zones/Deploy-AMBA-Web.jsonc'
-        Test-Path $assignmentFile | Should -BeTrue
+       foreach ($assignmentName in @('Deploy-AMBA-Web','Deploy-AMBA-VM','Deploy-AMBA-HybridVM','Deploy-AMBA-VMSS','Deploy-AMBA-Management')) {
+           $assignmentFile = Join-Path $definitionsRoot "policyAssignments/AMBA/epac-dev/Landing Zones/$assignmentName.jsonc"
+           Test-Path $assignmentFile | Should -BeTrue
 
-        $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
-        $assignment.parameters.ALZMonitorResourceGroupName | Should -Be 'rg-from-structure'
-        $assignment.additionalRoleAssignments.'epac-dev'[0].scope | Should -Be '/providers/Microsoft.Management/managementGroups/management'
-        $assignment.additionalRoleAssignments.'epac-dev'[0].roleDefinitionId | Should -Be '/providers/microsoft.authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
-    }
+           $assignment = Get-Content -Path $assignmentFile -Raw | ConvertFrom-Json
+           $assignment.parameters.ALZMonitorResourceGroupName | Should -Be 'rg-from-structure'
+           $assignment.additionalRoleAssignments.'epac-dev'[0].scope | Should -Be '/providers/Microsoft.Management/managementGroups/management'
+           $assignment.additionalRoleAssignments.'epac-dev'[0].roleDefinitionId | Should -Be '/providers/microsoft.authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
+       }
+   }
 }


### PR DESCRIPTION
AMBA assignment sync was only emitting `additionalRoleAssignments` for `Deploy-AMBA-Web`, which left the VM, HybridVM, VMSS, and Management assignments without the required Managed Identity Operator grant when BYO UAMI is used. This change aligns AMBA assignment generation so all affected assignments receive the same additional role assignment block.

## What changed
- Generalized AMBA sync handling in `Sync-ALZPolicyFromLibrary.ps1` to add `additionalRoleAssignments` for:
  - `Deploy-AMBA-Web`
  - `Deploy-AMBA-VM`
  - `Deploy-AMBA-HybridVM`
  - `Deploy-AMBA-VMSS`
  - `Deploy-AMBA-Management`
- Ensured those AMBA assignments are serialized with `additionalRoleAssignments` in the generated assignment JSON.
- Updated default ALZ/SLZ library tags in both scaffold and sync scripts:
  - `platform/alz/2026.08.0`
  - `platform/slz/2026.08.0`
- Expanded the AMBA sync unit test to validate the additional role assignment behavior across all affected AMBA assignments.

## Notes
- Scope and role used for AMBA additional role assignments remain unchanged from the existing Web behavior.

Fixes: #1370