### PR TITLE
Fix userAssignedIdentity array format for per-definitionEntry identities

### DIFF
--- a/Scripts/Helpers/Add-SelectedPacValue.ps1
+++ b/Scripts/Helpers/Add-SelectedPacValue.ps1
@@ -11,7 +11,10 @@ function Add-SelectedPacValue {
         [hashtable] $OutputObject,
 
         [Parameter(Mandatory = $true)]
-        [string] $OutputKey
+        [string] $OutputKey,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $AllowArray
     )
 
     $value = $InputObject.$PacSelector
@@ -20,7 +23,7 @@ function Add-SelectedPacValue {
     }
 
     if ($null -ne $value) {
-        if ($value -is [array]) {
+        if ($value -is [array] -and -not $AllowArray) {
             Write-Error "Value for '$PacSelector' is an array. It must be a single value. value is $(ConvertTo-Json $InputObject -Depth 100 -Compress)" -ErrorAction Stop
         }
         $OutputObject[$OutputKey] = $value

--- a/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
@@ -424,43 +424,41 @@ function Build-AssignmentDefinitionAtLeaf {
                     $identity = $userAssignedIdentityRaw
                 }
                 elseif ($userAssignedIdentityRaw -is [array]) {
+                    $entryPolicyName = $definitionEntry.policyName
+                    $entryPolicySetName = $definitionEntry.policySetName
                     foreach ($item in $userAssignedIdentityRaw) {
+                        $itemPolicySetName = $item.policySetName
+                        $itemPolicySetId = $item.policySetId
+                        $itemPolicyName = $item.policyName
+                        $itemPolicyId = $item.policyId
+                        if ($null -eq $itemPolicySetName -and $null -eq $itemPolicySetId -and $null -eq $itemPolicyName -and $null -eq $itemPolicyId) {
+                            Write-Error "    Leaf Node $($nodeName): each userAssignedIdentity entry must specify which definition in the definitionEntryList it belongs to by using one of policySetName, policySetId, policyName or policyId: $($userAssignedIdentityRaw | ConvertTo-Json -Depth 100 -Compress)"
+                            $hasErrors = $true
+                            continue
+                        }
+                        # an entry targeting a Policy Set never matches a Policy definitionEntry and vice versa
                         if ($isPolicySet) {
-                            $policySetName = $item.policySetName
-                            $policySetId = $item.policySetId
-                            if ($null -ne $policySetName) {
-                                if ($name -eq $policySetName) {
+                            if ($null -ne $itemPolicySetName) {
+                                if ($entryPolicySetName -eq $itemPolicySetName) {
                                     $identity = $item.identity
                                 }
                             }
-                            elseif ($null -ne $policySetId) {
-                                if ($policyDefinitionId -eq $policySetId) {
+                            elseif ($null -ne $itemPolicySetId) {
+                                if ($policyDefinitionId -eq $itemPolicySetId) {
                                     $identity = $item.identity
                                 }
-                            }
-                            else {
-                                Write-Error "    Leaf Node $($nodeName): userAssignedIdentity must specify which Policy Set in the definitionEntryList they belong to by either using policySetName or policySetId: $($userAssignedIdentityRaw | ConvertTo-Json -Depth 100 -Compress)"
-                                $hasErrors = $true
-                                continue
                             }
                         }
                         else {
-                            $policyName = $item.policyName
-                            $policyId = $item.policyId
-                            if ($null -ne $policyName) {
-                                if ($name -eq $policyName) {
+                            if ($null -ne $itemPolicyName) {
+                                if ($entryPolicyName -eq $itemPolicyName) {
                                     $identity = $item.identity
                                 }
                             }
-                            elseif ($null -ne $policyId) {
-                                if ($policyDefinitionId -eq $policyId) {
+                            elseif ($null -ne $itemPolicyId) {
+                                if ($policyDefinitionId -eq $itemPolicyId) {
                                     $identity = $item.identity
                                 }
-                            }
-                            else {
-                                Write-Error "    Leaf Node $($nodeName): userAssignedIdentity must specify which Policy in the definitionEntryList they belong to by either using policyName or policyId: $($userAssignedIdentityRaw | ConvertTo-Json -Depth 100 -Compress)"
-                                $hasErrors = $true
-                                continue
                             }
                         }
                     }

--- a/Scripts/Helpers/Build-AssignmentDefinitionEntry.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionEntry.ps1
@@ -39,6 +39,9 @@ function Build-AssignmentDefinitionEntry {
                     policyDefinitionId = $policyId
                     isPolicySet        = $false
                 }
+                if ($null -ne $policyName) {
+                    $normalizedEntry.policyName = $policyName
+                }
             }
         }
         elseif ($null -ne $policySetName -or $null -ne $policySetId) {
@@ -55,6 +58,9 @@ function Build-AssignmentDefinitionEntry {
                     policyDefinitionId = $policySetId
                     isPolicySet        = $true
                 }
+                if ($null -ne $policySetName) {
+                    $normalizedEntry.policySetName = $policySetName
+                }
             }
         }
         elseif ($null -ne $initiativeName -or $null -ne $initiativeId) {
@@ -70,6 +76,9 @@ function Build-AssignmentDefinitionEntry {
                 $normalizedEntry = @{
                     policyDefinitionId = $policySetId
                     isPolicySet        = $true
+                }
+                if ($null -ne $initiativeName) {
+                    $normalizedEntry.policySetName = $initiativeName
                 }
             }
         }

--- a/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionNode.ps1
@@ -544,7 +544,8 @@ function Build-AssignmentDefinitionNode {
 
     if ($DefinitionNode.userAssignedIdentity) {
         # Process userAssignedIdentity; can be overridden
-        Add-SelectedPacValue -InputObject $DefinitionNode.userAssignedIdentity -PacSelector $pacSelector -OutputObject $definition -OutputKey "userAssignedIdentity"
+        # An array is allowed here to support per definitionEntryList identities; resolved in Build-AssignmentDefinitionAtLeaf
+        Add-SelectedPacValue -InputObject $DefinitionNode.userAssignedIdentity -PacSelector $pacSelector -OutputObject $definition -OutputKey "userAssignedIdentity" -AllowArray
     }
     #endregion identity and additionalRoleAssignments (optional, specific to an EPAC environment)
 


### PR DESCRIPTION
## Why

The documented array form of `userAssignedIdentity`, which lets you assign a different identity per entry in a `definitionEntryList`, did not work at all:

```
Value for 'myPacEnvironment' is an array. It must be a single value.
at Build-AssignmentDefinitionNode.ps1:547
```

Reproduced against a live tenant before changing anything.

## What was actually wrong

The reported error is real, but fixing only that surfaces a second, quieter bug. There are three related defects:

1. **`Add-SelectedPacValue.ps1`** hard-stops on arrays, so the value never reached the leaf handler that knows how to resolve it. It now takes an opt-in `-AllowArray` switch. `userAssignedIdentity` is the only caller that passes it, so every other key (`managedIdentityLocation`, etc.) still rejects arrays as before.

2. **`Build-AssignmentDefinitionEntry.ps1`** normalized each entry down to just `policyDefinitionId` and `isPolicySet`, discarding the source `policySetName` / `policyName`. The leaf matcher then had nothing correct to compare against.

3. **`Build-AssignmentDefinitionAtLeaf.ps1`** compared the array's `policySetName` against `$name`, which is the *assignment* name, not the policy set name. That comparison can never match, so with only fix 1 applied the build succeeds but silently falls back to `SystemAssigned` - worse than the original hard failure. It also raised an error for any array entry whose type did not match the current `definitionEntry`, which broke a `definitionEntryList` mixing Policies and Policy Sets.

Matching is now key-agnostic across `policySetName`, `policySetId`, `policyName`, and `policyId`, and only errors when an entry specifies none of the four. Legacy `initiativeName` is carried through as `policySetName` so it behaves the same.

## Verification

Built plans against a real management group with assignments covering each matching path:

| Assignment | Resolved identity |
| --- | --- |
| array by `policySetName` (set A) | `identity-gc` |
| array by `policySetName` (set B) | `identity-sql` |
| array by `policySetId` | `identity-byid` |
| array by `policyName` (mixed list) | `identity-byname` |
| single string (regression control) | `identity-gc` |

Before the fix the four array cases were `SystemAssigned`. Also confirmed that an array entry with no selector key still fails the build, that other config keys still reject arrays, and that all 50 existing Pester tests pass.

## Note for reviewers

Worth a careful look at defect 3. The silent `SystemAssigned` fallback is the dangerous part of this bug: a plan would build cleanly while deploying the wrong identity, so anyone who worked around the original error by other means may have been affected.

Fixes: #1379