### PR TITLE
Fix exemption plan crash for APIM AIGateway SKU (#1377)

### DIFF
--- a/Scripts/Helpers/RestMethods/Get-AzResourceListRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Get-AzResourceListRestMethod.ps1
@@ -6,7 +6,7 @@ function Get-AzResourceListRestMethod {
 
         [switch]$CheckCustomRoleDefinitions
     )
-    
+
     function Invoke-AzRestMethodCustom {
         [CmdletBinding()]
         param (
@@ -15,7 +15,7 @@ function Get-AzResourceListRestMethod {
             [Parameter(Mandatory = $true)]
             $method
         )
-        
+
         $response = Invoke-AzRestMethod -Path $path -Method $method
 
         # Process response
@@ -23,7 +23,7 @@ function Get-AzResourceListRestMethod {
         if ($statusCode -lt 200 -or $statusCode -ge 300) {
             $content = $response.Content
             Write-Warning "Policy Exemption error for scope '$Scope' $($statusCode) -- $($content)"
-            Write-Output @() -NoEnumerate
+            return @{ value = @() }
         }
 
         $content = $response.Content
@@ -38,36 +38,43 @@ function Get-AzResourceListRestMethod {
         return $resources
     }
 
-    # Get the basic resources    
+    # Get the basic resources
     $ApiVersion = "2021-04-01"
     $path = "/subscriptions/$SubscriptionId/resources?api-version=$ApiVersion"
     $resources = Invoke-AzRestMethodCustom -path $path -method GET
 
     # Get the Subnets for all the Vnets found in the basic resources
     $snets = $($resources.value | Where-Object { $_.type -eq 'Microsoft.Network/virtualNetworks' })
-    foreach ($snet in $snets) {   
+    foreach ($snet in $snets) {
         $ApiVersion = "2024-01-01"
         $path = "$($snet.id)/subnets?api-version=$ApiVersion"
         $subnetResources = Invoke-AzRestMethodCustom -path $path -method GET
-        $resources.value += $subnetResources.value
+        if ($null -ne $subnetResources.value) {
+            $resources.value += $subnetResources.value
+        }
     }
 
     # Get the automation account variables for all the automation accounts found in the basic resources
     $automationAccounts = $($resources.value | Where-Object { $_.type -eq 'Microsoft.Automation/automationAccounts' })
-    foreach ($account in $automationAccounts) {   
+    foreach ($account in $automationAccounts) {
         $ApiVersion = "2023-11-01"
         $path = "$($account.id)/variables?api-version=$ApiVersion"
         $variableResources = Invoke-AzRestMethodCustom -path $path -method GET
-        $resources.value += $variableResources.value
+        if ($null -ne $variableResources.value) {
+            $resources.value += $variableResources.value
+        }
     }
 
     # Get APIM APIs for all API Management services found in the basic resources
-    $apiManagementServices = $($resources.value | Where-Object { $_.type -eq 'Microsoft.ApiManagement/service' })
+    # AIGateway SKU does not support the APIs or Named Values operations (MethodNotAllowedInPricingTier), so exclude it
+    $apiManagementServices = $($resources.value | Where-Object { $_.type -eq 'Microsoft.ApiManagement/service' -and $_.sku.name -ne 'AIGateway' })
     foreach ($apiManagementService in $apiManagementServices) {
         $ApiVersion = "2024-05-01"
         $path = "$($apiManagementService.id)/apis?api-version=$ApiVersion"
         $apiResources = Invoke-AzRestMethodCustom -path $path -method GET
-        $resources.value += $apiResources.value
+        if ($null -ne $apiResources.value) {
+            $resources.value += $apiResources.value
+        }
     }
 
     # Get APIM named values for all API Management services found in the basic resources
@@ -75,7 +82,9 @@ function Get-AzResourceListRestMethod {
         $ApiVersion = "2024-05-01"
         $path = "$($apiManagementService.id)/namedValues?api-version=$ApiVersion"
         $namedValueResources = Invoke-AzRestMethodCustom -path $path -method GET
-        $resources.value += $namedValueResources.value
+        if ($null -ne $namedValueResources.value) {
+            $resources.value += $namedValueResources.value
+        }
     }
 
     # Get the custom role definitions if requested
@@ -83,7 +92,9 @@ function Get-AzResourceListRestMethod {
         $ApiVersion = "2022-04-01"
         $path = "/subscriptions/$SubscriptionId/providers/Microsoft.Authorization/roleDefinitions?api-version=$ApiVersion&`$filter=type eq 'CustomRole'"
         $customRoleDefinitions = Invoke-AzRestMethodCustom -path $path -method GET
-        $resources.value += $customRoleDefinitions.value
+        if ($null -ne $customRoleDefinitions.value) {
+            $resources.value += $customRoleDefinitions.value
+        }
     }
 
     Write-Output $resources.value -NoEnumerate


### PR DESCRIPTION
- Exclude API Management services with the AIGateway SKU from the custom APIs/NamedValues lookups, since that pricing tier returns MethodNotAllowedInPricingTier for those operations.
- Return an empty value array from Invoke-AzRestMethodCustom on non-2xx responses instead of falling through to parse the error body as a success payload.
- Guard every $resources.value += ... append with a null check to prevent null entries from reaching downstream ContainsKey lookups.
- Minor whitespace cleanup (trailing spaces).