### PR TITLE
Add Mission Landing Zone (MLZ) policy structure and assignment sync

### DIFF
--- a/.github/workflows/check-mlz-policy-changes.yaml
+++ b/.github/workflows/check-mlz-policy-changes.yaml
@@ -1,0 +1,133 @@
+name: Check MLZ Policy Changes
+
+# Mission Landing Zone does not publish releases on a cadence (the only tag pre-dates the
+# current policy content), so this watches commits to the paths the MLZ sync reads instead.
+
+on:
+    schedule:
+        - cron: '30 8 * * *'  # Every day at 8:30 AM
+    workflow_dispatch:
+        inputs:
+            lookbackHours:
+                description: 'How many hours of upstream history to inspect'
+                required: false
+                default: '25'
+
+permissions:
+    contents: read
+    issues: write
+
+env:
+    MLZ_REPOSITORY: Azure/missionlz
+    MLZ_BRANCH: main
+    ISSUE_TITLE: Upstream Mission Landing Zone policy changes detected
+
+jobs:
+    check-and-create-issue:
+        runs-on: windows-latest
+        defaults:
+            run:
+                shell: pwsh
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Check for upstream policy changes
+              id: check
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  LOOKBACK_HOURS: ${{ github.event.inputs.lookbackHours || '25' }}
+              run: |
+                  $ErrorActionPreference = 'Stop'
+
+                  # Paths consumed by Sync-ALZPolicyFromLibrary -Type MLZ and used to derive
+                  # the cloud conditional behaviour in New-ALZPolicyDefaultStructure.
+                  $watchedPaths = @(
+                      'src/policies'
+                      'src/modules/policy-assignment.bicep'
+                  )
+
+                  $lookbackHours = [int] $env:LOOKBACK_HOURS
+                  $since = (Get-Date).ToUniversalTime().AddHours(-$lookbackHours).ToString('yyyy-MM-ddTHH:mm:ssZ')
+                  Write-Host "Inspecting $($env:MLZ_REPOSITORY)@$($env:MLZ_BRANCH) for commits since $since"
+
+                  $commits = [ordered]@{}
+                  foreach ($path in $watchedPaths) {
+                      $uri = "repos/$($env:MLZ_REPOSITORY)/commits?sha=$($env:MLZ_BRANCH)&path=$path&since=$since&per_page=100"
+                      $raw = gh api $uri
+                      if ($LASTEXITCODE -ne 0) {
+                          throw "Failed to query $uri"
+                      }
+
+                      foreach ($commit in ($raw | ConvertFrom-Json)) {
+                          if (-not $commits.Contains($commit.sha)) {
+                              # ConvertFrom-Json turns the ISO 8601 timestamp into a local DateTime,
+                              # so normalise it back to UTC rather than rendering it culture specific.
+                              $committedUtc = ([datetime] $commit.commit.committer.date).ToUniversalTime()
+
+                              $commits[$commit.sha] = [pscustomobject]@{
+                                  Sha     = $commit.sha
+                                  Date    = $committedUtc.ToString('yyyy-MM-ddTHH:mm:ssZ')
+                                  Subject = ($commit.commit.message -split "`n")[0]
+                                  Url     = $commit.html_url
+                                  Paths   = [System.Collections.Generic.List[string]]::new()
+                              }
+                          }
+                          $commits[$commit.sha].Paths.Add($path)
+                      }
+                  }
+
+                  if ($commits.Count -eq 0) {
+                      Write-Host "No changes to the watched paths."
+                      "changed=false" >> $env:GITHUB_OUTPUT
+                      return
+                  }
+
+                  Write-Host "Found $($commits.Count) commit(s) touching the watched paths."
+
+                  $lines = [System.Collections.Generic.List[string]]::new()
+                  $lines.Add("New commits were pushed to [``$($env:MLZ_REPOSITORY)``](https://github.com/$($env:MLZ_REPOSITORY)) affecting the policy content that the EPAC MLZ sync reads.")
+                  $lines.Add('')
+                  $lines.Add("Window inspected: last $lookbackHours hour(s) on ``$($env:MLZ_BRANCH)``.")
+                  $lines.Add('')
+                  $lines.Add('| Commit | Date (UTC) | Watched paths | Subject |')
+                  $lines.Add('| --- | --- | --- | --- |')
+                  foreach ($commit in $commits.Values) {
+                      $shortSha = $commit.Sha.Substring(0, 7)
+                      $paths = (($commit.Paths | Sort-Object -Unique) -join '<br>')
+                      $subject = $commit.Subject -replace '\|', '\|'
+                      $lines.Add("| [``$shortSha``]($($commit.Url)) | $($commit.Date) | ``$paths`` | $subject |")
+                  }
+                  $lines.Add('')
+                  $lines.Add('### What to check')
+                  $lines.Add('')
+                  $lines.Add('- Whether `src/policies` gained, lost or renamed a parameter file. The MLZ sync maps a fixed set of baselines onto built-in policy set IDs, so a new baseline needs a new mapping in `Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1`.')
+                  $lines.Add('- Whether `src/modules/policy-assignment.bicep` changed the built-in `policySetDefinitionId` values or the cloud conditional logic (for example the `AzureCloud` IL5 to NISTRev4 substitution, or the extra CMMC membership parameters).')
+                  $lines.Add('- Whether any newly added parameters should be surfaced as `defaultParameterValues` stubs by `Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1 -Type MLZ`.')
+                  $lines.Add('')
+                  $lines.Add('Re-run `Tests/CloudAdoptionFramework` after any change.')
+                  $lines.Add('')
+                  $lines.Add('_Raised automatically by the `Check MLZ Policy Changes` workflow._')
+
+                  Set-Content -Path 'mlz-changes.md' -Value $lines -Encoding utf8
+                  "changed=true" >> $env:GITHUB_OUTPUT
+
+            - name: Create or update issue
+              if: ${{ steps.check.outputs.changed == 'true' }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  $ErrorActionPreference = 'Stop'
+
+                  # Avoid piling up a new issue every day while an existing report is still open.
+                  $existing = gh issue list --state open --search "`"$($env:ISSUE_TITLE)`" in:title" --json number,title | ConvertFrom-Json
+                  $match = $existing | Where-Object { $_.title -eq $env:ISSUE_TITLE } | Select-Object -First 1
+
+                  if ($null -ne $match) {
+                      Write-Host "Commenting on existing issue #$($match.number)."
+                      gh issue comment $match.number --body-file 'mlz-changes.md'
+                  }
+                  else {
+                      Write-Host "Creating a new issue."
+                      gh issue create --title $env:ISSUE_TITLE --body-file 'mlz-changes.md'
+                  }

--- a/Docs/integrating-with-alz-library.md
+++ b/Docs/integrating-with-alz-library.md
@@ -238,7 +238,7 @@ Changing the cloud and re-running the sync removes any assignment file that is n
 
 ##### Other notes
 
-- missionlz has no usable release tag - its only tag predates the current `src/policies` content - so the default branch is cloned. Generated output can therefore change when the upstream repository changes.
+- missionlz has no usable release tag - its only tag predates the current `src/policies` content - so the default branch is cloned. Generated output can therefore change when the upstream repository changes. The `Check MLZ Policy Changes` workflow (`.github/workflows/check-mlz-policy-changes.yaml`) runs daily and raises an issue when `src/policies` or `src/modules/policy-assignment.bicep` change upstream, so the sync scripts can be reviewed against them.
 - The sync warns if the subscription scope is still the placeholder or if any of the runtime values above are still empty. It completes anyway so the output can be inspected.
 - Role assignments and policy remediation tasks created by the MLZ deployment are not reproduced. Configure those through the usual EPAC mechanisms.
 

--- a/Docs/integrating-with-alz-library.md
+++ b/Docs/integrating-with-alz-library.md
@@ -171,6 +171,29 @@ New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions -Type SLZ -Pa
 Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type SLZ -PacEnvironmentSelector "epac-dev"
 ```
 
+### MLZ
+
+[Mission Landing Zone](https://github.com/Azure/missionlz) (MLZ) is an Azure landing zone for SCCA-compliant organizations. Unlike ALZ, AMBA, FSI and SLZ it is **not** published through the Azure Landing Zones Library, so the MLZ type uses a completely separate code path.
+
+```ps1
+# Create a Pac Environment default file for MLZ policies
+New-ALZPolicyDefaultStructure -DefinitionsRootFolder .\Definitions -Type MLZ -PacEnvironmentSelector "epac-dev"
+```
+
+Notes specific to MLZ:
+
+- No library repository is cloned and the `-Tag` parameter is not required (and is ignored for tag validation), so the command works without network access.
+- MLZ assigns policy at **subscription** scope rather than management group scope. The generated file contains a single placeholder entry which must be updated with your MLZ subscription ID.
+
+  ```json
+  "mlz": {
+    "management_group_function": "Mission Landing Zone",
+    "value": "/subscriptions/00000000-0000-0000-0000-000000000000" // replace with your MLZ subscription ID
+  }
+  ```
+
+- `defaultParameterValues` is intentionally generated empty. The MLZ compliance baselines (CMMC, IL5, NIST SP 800-53 Rev. 4 and Rev. 5) carry several hundred parameters between them, so those values are produced together with the policy assignments during the sync step rather than being stubbed into the structure file.
+
 ## Advanced Scenarios
 
 Using the format of the Azure Landing Zones repository it is possible to enable some advanced scenarios. Many of these are based around customization to the recommended ALZ management group structure. It is recommended to maintain your own fork of the ALZ Library in some of these cases.

--- a/Docs/integrating-with-alz-library.md
+++ b/Docs/integrating-with-alz-library.md
@@ -192,7 +192,55 @@ Notes specific to MLZ:
   }
   ```
 
-- `defaultParameterValues` is intentionally generated empty. The MLZ compliance baselines (CMMC, IL5, NIST SP 800-53 Rev. 4 and Rev. 5) carry several hundred parameters between them, so those values are produced together with the policy assignments during the sync step rather than being stubbed into the structure file.
+- `defaultParameterValues` only contains the handful of values that the MLZ deployment injects at runtime and which cannot be read from the missionlz repository. Populate them before running the sync; each one is applied to every assignment that needs it, under whichever parameter name that baseline uses.
+
+  | Structure file value | Applied to |
+  | --- | --- |
+  | `log_analytics_workspace_resource_id` | `NISTRev4`, `IL5`, `Deploy-VM-Agents`, `Deploy-VMSS-Agents` |
+  | `log_analytics_workspace_customer_id` | `CMMC` — this is the workspace **customer ID** (a GUID), not the resource ID |
+  | `windows_administrators_group_membership` | `NISTRev4`, `IL5`, `CMMC` |
+  | `windows_administrators_group_exclusions` | `CMMC`, pre-filled with `admin` to match the MLZ deployment |
+
+  The compliance baselines themselves (CMMC, IL5, NIST SP 800-53 Rev. 4 and Rev. 5) carry several hundred parameters between them. Those are **not** stubbed into the structure file - they are read from the missionlz repository during the sync step.
+
+#### Syncing MLZ assignments
+
+```ps1
+# Generate the MLZ policy assignments
+Sync-ALZPolicyFromLibrary -DefinitionsRootFolder .\Definitions -Type MLZ -PacEnvironmentSelector "epac-dev"
+```
+
+This clones <https://github.com/Azure/missionlz>, reads the assignment parameter files from `src/policies` and writes the assignments to `Definitions\policyAssignments\MLZ\<PacEnvironmentSelector>\<management_group_function>\`. Use `-LibraryPath` to point at an existing local checkout instead of cloning.
+
+MLZ has no custom policy or policy set definitions - every baseline is a built-in initiative - so nothing is written to `policyDefinitions` or `policySetDefinitions`. `-SyncAssignmentsOnly` therefore has no effect, and `-CreateGuardrailAssignments`, `-EnableOverrides` and `-SyncAMBAExtendedPolicies` are not applicable.
+
+Six assignments are generated:
+
+| File | Initiative |
+| --- | --- |
+| `CMMC.jsonc` | CMMC Level 3 |
+| `IL5.jsonc` | DoD Impact Level 5 |
+| `NISTRev4.jsonc` | NIST SP 800-53 Rev. 4 |
+| `NISTRev5.jsonc` | NIST SP 800-53 Rev. 5 |
+| `Deploy-VM-Agents.jsonc` | Virtual machine monitoring agents |
+| `Deploy-VMSS-Agents.jsonc` | Virtual machine scale set monitoring agents |
+
+The MLZ deployment assigns exactly one compliance baseline per resource group. EPAC generates all of the applicable baselines so you can choose between them - delete the assignment files you do not want before deploying, otherwise overlapping baselines are applied to the same subscription.
+
+##### Cloud specific behaviour
+
+The MLZ deployment branches on the Azure environment, and the sync reproduces this using the `cloud` property of the PAC environment in `global-settings.jsonc` that matches `-PacEnvironmentSelector`. If it cannot be resolved, `AzureCloud` is assumed and a warning is emitted.
+
+- **`AzureCloud`** - the deployment maps IL5 to NIST SP 800-53 Rev. 4, so `IL5.jsonc` is **not** generated (`NISTRev4.jsonc` covers it). The CMMC assignment additionally receives the Windows administrators group include and exclude parameters.
+- **Any other cloud** (for example `AzureUSGovernment`) - all six assignments are generated and the two CMMC administrators group parameters are omitted.
+
+Changing the cloud and re-running the sync removes any assignment file that is no longer generated, so the switch is handled in both directions.
+
+##### Other notes
+
+- missionlz has no usable release tag - its only tag predates the current `src/policies` content - so the default branch is cloned. Generated output can therefore change when the upstream repository changes.
+- The sync warns if the subscription scope is still the placeholder or if any of the runtime values above are still empty. It completes anyway so the output can be inspected.
+- Role assignments and policy remediation tasks created by the MLZ deployment are not reproduced. Configure those through the usual EPAC mechanisms.
 
 ## Advanced Scenarios
 

--- a/Schemas/policy-structure-schema.json
+++ b/Schemas/policy-structure-schema.json
@@ -17,16 +17,16 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "pattern": "^/providers/Microsoft\\.Management/managementGroups/[a-zA-Z0-9_-]+$",
-                                    "description": "The full resource path to the management group"
+                                    "pattern": "^(/providers/Microsoft\\.Management/managementGroups/[a-zA-Z0-9_-]+|/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+                                    "description": "The full resource path to the management group, or to a subscription for platforms such as MLZ that assign at subscription scope"
                                 },
                                 {
                                     "type": "array",
                                     "items": {
                                         "type": "string",
-                                        "pattern": "^/providers/Microsoft\\.Management/managementGroups/[a-zA-Z0-9_-]+$"
+                                        "pattern": "^(/providers/Microsoft\\.Management/managementGroups/[a-zA-Z0-9_-]+|/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
                                     },
-                                    "description": "Array of resource paths to management groups"
+                                    "description": "Array of resource paths to management groups or subscriptions"
                                 }
                             ]
                         }

--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -70,8 +70,12 @@ else {
 # structure - no architecture definitions, archetypes or alz_policy_default_values.json. Its policy content
 # is a set of flat parameter maps under src/policies that are assigned against built-in initiatives at
 # subscription/resource group scope. The structure file therefore cannot be produced by the library code
-# path below and is built here instead. Default parameter values are intentionally left empty; they are
-# populated alongside the assignments during the sync step.
+# path below and is built here instead.
+#
+# Only the handful of values that src/modules/policy-assignment.bicep injects at deployment time are stubbed
+# here, because they cannot be sourced from the repository. The several hundred baseline parameter values are
+# deliberately not stubbed - they are read straight from the cloned missionlz repository during the sync step.
+# Each stub fans out to the differently named parameter that each baseline uses for the same underlying value.
 if ($Type -eq 'MLZ') {
     Write-ModernSection -Title "Building MLZ Structure" -Indent 0
 
@@ -84,14 +88,91 @@ if ($Type -eq 'MLZ') {
             }
         }
         enforcementMode             = "Default"
-        defaultParameterValues      = [ordered]@{}
+        defaultParameterValues      = [ordered]@{
+            log_analytics_workspace_resource_id     = @(
+                [ordered]@{
+                    policy_assignment_name = "NISTRev4"
+                    description            = "Resource ID of the Log Analytics workspace used for VM reporting."
+                    parameters             = [ordered]@{
+                        parameter_name = "logAnalyticsWorkspaceIdforVMReporting"
+                        value          = ""
+                    }
+                }
+                [ordered]@{
+                    policy_assignment_name = "IL5"
+                    description            = "Resource ID of the Log Analytics workspace used by the VM agents."
+                    parameters             = [ordered]@{
+                        parameter_name = "logAnalyticsWorkspaceIDForVMAgents"
+                        value          = ""
+                    }
+                }
+                [ordered]@{
+                    policy_assignment_name = @(
+                        "Deploy-VMSS-Agents"
+                        "Deploy-VM-Agents"
+                    )
+                    description            = "Resource ID of the Log Analytics workspace the deployed agents report to."
+                    parameters             = [ordered]@{
+                        parameter_name = "logAnalytics_1"
+                        value          = ""
+                    }
+                }
+            )
+            log_analytics_workspace_customer_id     = @(
+                [ordered]@{
+                    policy_assignment_name = "CMMC"
+                    description            = "Customer ID (workspace ID GUID, not the resource ID) of the Log Analytics workspace."
+                    parameters             = [ordered]@{
+                        parameter_name = "logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917"
+                        value          = ""
+                    }
+                }
+            )
+            windows_administrators_group_membership = @(
+                [ordered]@{
+                    policy_assignment_name = "NISTRev4"
+                    description            = "Members to include in the Windows VM local administrators group."
+                    parameters             = [ordered]@{
+                        parameter_name = "listOfMembersToIncludeInWindowsVMAdministratorsGroup"
+                        value          = ""
+                    }
+                }
+                [ordered]@{
+                    policy_assignment_name = "IL5"
+                    description            = "Members to include in the Windows VM local administrators group."
+                    parameters             = [ordered]@{
+                        parameter_name = "membersToIncludeInLocalAdministratorsGroup"
+                        value          = ""
+                    }
+                }
+                [ordered]@{
+                    policy_assignment_name = "CMMC"
+                    description            = "Members to include in the Windows VM local administrators group. Only assigned in Azure commercial."
+                    parameters             = [ordered]@{
+                        parameter_name = "MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7"
+                        value          = ""
+                    }
+                }
+            )
+            windows_administrators_group_exclusions  = @(
+                [ordered]@{
+                    policy_assignment_name = "CMMC"
+                    description            = "Members to exclude from the Windows VM local administrators group. Only assigned in Azure commercial."
+                    parameters             = [ordered]@{
+                        parameter_name = "MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f"
+                        value          = "admin"
+                    }
+                }
+            )
+        }
         enforceGuardrails           = @{
             deployments = @()
         }
     }
 
     Write-ModernStatus -Message "Added placeholder scope 'mlz' - replace the subscription id with the target subscription" -Status "info" -Indent 2
-    Write-ModernStatus -Message "Default parameter values are created during the sync step" -Status "info" -Indent 2
+    Write-ModernStatus -Message "Added deployment time parameter stubs - populate them before running the sync" -Status "info" -Indent 2
+    Write-ModernStatus -Message "Baseline parameter values are read from the missionlz repository during the sync step" -Status "info" -Indent 2
 
     Write-ModernSection -Title "Writing Output Files" -Indent 0
     $mlzOutputDirectory = "$DefinitionsRootFolder\policyStructures"

--- a/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
+++ b/Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1
@@ -3,12 +3,11 @@ Param(
     [Parameter(Mandatory = $true)]
     [string] $DefinitionsRootFolder,
 
-    [ValidateSet('ALZ', 'FSI', 'AMBA', 'SLZ')]
+    [ValidateSet('ALZ', 'FSI', 'AMBA', 'SLZ', 'MLZ')]
     [string] $Type = 'ALZ',
 
     [string] $LibraryPath,
 
-    [ValidateScript({ "refs/tags/$_" -in (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref }, ErrorMessage = "Tag must be a valid tag." )]
     [string] $Tag,
 
     [Parameter(Mandatory = $true)]
@@ -17,6 +16,15 @@ Param(
 
 # Dot Source Helper Scripts
 . "$PSScriptRoot/../Helpers/Add-HelperScripts.ps1"
+
+# MLZ is sourced from a different repository (Azure/missionlz) so the Azure Landing Zones Library tag
+# list does not apply to it. Validate the tag at runtime for every other type instead of using a
+# parameter attribute, otherwise the MLZ code path would be forced to supply an ALZ library tag.
+if ($Type -ne 'MLZ' -and -not [string]::IsNullOrWhiteSpace($Tag)) {
+    if ("refs/tags/$Tag" -notin (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref) {
+        throw "Tag must be a valid tag."
+    }
+}
 
 if ($DefinitionsRootFolder -eq "") {
     if ($null -eq $env:PAC_DEFINITIONS_FOLDER) {
@@ -50,7 +58,60 @@ if ($Tag -eq "") {
     }
 }
 
-Write-ModernHeader -Title "Creating Policy Default Structure" -Subtitle "Type: $Type, Tag: $Tag"
+if ($Type -eq 'MLZ') {
+    Write-ModernHeader -Title "Creating Policy Default Structure" -Subtitle "Type: $Type"
+}
+else {
+    Write-ModernHeader -Title "Creating Policy Default Structure" -Subtitle "Type: $Type, Tag: $Tag"
+}
+
+#region MLZ
+# Mission Landing Zone (https://github.com/Azure/missionlz) has none of the Azure Landing Zones Library
+# structure - no architecture definitions, archetypes or alz_policy_default_values.json. Its policy content
+# is a set of flat parameter maps under src/policies that are assigned against built-in initiatives at
+# subscription/resource group scope. The structure file therefore cannot be produced by the library code
+# path below and is built here instead. Default parameter values are intentionally left empty; they are
+# populated alongside the assignments during the sync step.
+if ($Type -eq 'MLZ') {
+    Write-ModernSection -Title "Building MLZ Structure" -Indent 0
+
+    $mlzOutput = [ordered]@{
+        "`$schema"                  = "https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-structure-schema.json"
+        managementGroupNameMappings = [ordered]@{
+            mlz = [ordered]@{
+                management_group_function = "Mission Landing Zone"
+                value                     = "/subscriptions/00000000-0000-0000-0000-000000000000"
+            }
+        }
+        enforcementMode             = "Default"
+        defaultParameterValues      = [ordered]@{}
+        enforceGuardrails           = @{
+            deployments = @()
+        }
+    }
+
+    Write-ModernStatus -Message "Added placeholder scope 'mlz' - replace the subscription id with the target subscription" -Status "info" -Indent 2
+    Write-ModernStatus -Message "Default parameter values are created during the sync step" -Status "info" -Indent 2
+
+    Write-ModernSection -Title "Writing Output Files" -Indent 0
+    $mlzOutputDirectory = "$DefinitionsRootFolder\policyStructures"
+    if (-not (Test-Path -Path $mlzOutputDirectory)) {
+        New-Item -ItemType Directory -Path $mlzOutputDirectory | Out-Null
+    }
+
+    if ($PacEnvironmentSelector) {
+        $mlzOutputFile = "$mlzOutputDirectory\mlz.policy_default_structure.$PacEnvironmentSelector.jsonc"
+    }
+    else {
+        $mlzOutputFile = "$mlzOutputDirectory\mlz.policy_default_structure.jsonc"
+    }
+
+    Out-File $mlzOutputFile -InputObject ($mlzOutput | ConvertTo-Json -Depth 10) -Encoding utf8 -Force
+    Write-ModernStatus -Message "Default structure file: $mlzOutputFile" -Status "success" -Indent 2
+    Write-ModernStatus -Message "MLZ Policy default structure created successfully" -Status "success" -Indent 0
+    return
+}
+#endregion MLZ
 
 if ($LibraryPath -eq "") {
     $LibraryPath = Join-Path -Path (Get-Location) -ChildPath "temp"

--- a/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
+++ b/Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory = $true)]
     [string] $DefinitionsRootFolder,
 
-    [ValidateSet("ALZ", "AMBA", "FSI", "SLZ")]
+    [ValidateSet("ALZ", "AMBA", "FSI", "SLZ", "MLZ")]
     [string] $Type = "ALZ",
 
     [Parameter(Mandatory = $true)]
@@ -10,7 +10,6 @@ Param(
 
     [string] $LibraryPath,
 
-    [ValidateScript({ "refs/tags/$_" -in (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref }, ErrorMessage = "Tag must be a valid tag." )]
     [string] $Tag,
 
     [switch] $CreateGuardrailAssignments,
@@ -26,6 +25,14 @@ Param(
 
 # Dot Source Helper Scripts
 . "$PSScriptRoot/../Helpers/Add-HelperScripts.ps1"
+
+# MLZ is sourced from Azure/missionlz which has no usable release tag, so the tag validation - which
+# calls the Azure Landing Zones Library API - is only applied to the library backed types.
+if ($Tag -and $Type -ne "MLZ") {
+    if ("refs/tags/$Tag" -notin (Invoke-RestMethod -Uri 'https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/git/refs/tags/').ref) {
+        throw "Tag must be a valid tag."
+    }
+}
 
 # Resolves the final archetype name after the mid-pipeline renames that are applied while
 # building the archetype array. Used in both the override-population path and the archetype-build
@@ -99,9 +106,14 @@ if ($Tag -eq "") {
     }
 }
 
-Write-ModernHeader -Title "Syncing Policies From Library" -Subtitle "Type: $Type, Tag: $Tag"
+if ($Type -eq "MLZ") {
+    Write-ModernHeader -Title "Syncing Policies From Library" -Subtitle "Type: MLZ (Azure/missionlz)"
+}
+else {
+    Write-ModernHeader -Title "Syncing Policies From Library" -Subtitle "Type: $Type, Tag: $Tag"
+}
 
-if ($LibraryPath -eq "") {
+if ($LibraryPath -eq "" -and $Type -ne "MLZ") {
     $LibraryPath = Join-Path -Path (Get-Location) -ChildPath "temp"
     # Check if the temp folder exists, and delete it if it does
     if (Test-Path $LibraryPath) {
@@ -173,6 +185,266 @@ catch {
 }
 
 $syncedPolicyDefinitionNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+#region MLZ
+# Mission Landing Zone (https://github.com/Azure/missionlz) shares no layout with the Azure Landing
+# Zones Library, so it gets a completely self contained code path. It has no custom policy or policy
+# set definitions - every baseline is a built-in initiative - so all this produces is assignments.
+if ($Type -eq "MLZ") {
+
+    foreach ($switchName in @("CreateGuardrailAssignments", "EnableOverrides", "SyncAMBAExtendedPolicies")) {
+        if ($PSBoundParameters.ContainsKey($switchName) -and $PSBoundParameters[$switchName]) {
+            Write-ModernStatus -Message "-$switchName is not applicable to MLZ and is ignored" -Status "warning" -Indent 2
+        }
+    }
+    if ($SyncAssignmentsOnly) {
+        Write-ModernStatus -Message "-SyncAssignmentsOnly has no effect for MLZ because assignments are the only output" -Status "info" -Indent 2
+    }
+
+    #region Resolve the cloud
+    # policy-assignment.bicep branches on environment().name, so the equivalent here is the cloud of
+    # the PAC environment being synced.
+    $mlzCloud = "AzureCloud"
+    try {
+        $mlzPacEnvironment = (Get-Content -Path "$DefinitionsRootFolder/global-settings.jsonc" -Raw -ErrorAction Stop | ConvertFrom-Json).pacEnvironments |
+            Where-Object { $_.pacSelector -eq $PacEnvironmentSelector } | Select-Object -First 1
+        if ($null -eq $mlzPacEnvironment) {
+            throw "no PAC environment with pacSelector '$PacEnvironmentSelector' was found"
+        }
+        if ([string]::IsNullOrWhiteSpace($mlzPacEnvironment.cloud)) {
+            throw "PAC environment '$PacEnvironmentSelector' does not specify a cloud"
+        }
+        $mlzCloud = $mlzPacEnvironment.cloud
+    }
+    catch {
+        Write-ModernStatus -Message "Could not resolve the cloud from global-settings.jsonc ($($_.Exception.Message)) - defaulting to 'AzureCloud'" -Status "warning" -Indent 2
+    }
+    # The bicep comparison is case insensitive, so this one is too.
+    $mlzIsCommercialCloud = $mlzCloud -eq "AzureCloud"
+    Write-ModernStatus -Message "Cloud: $mlzCloud" -Status "info" -Indent 2
+    #endregion Resolve the cloud
+
+    #region Source repository
+    $mlzTempPath = $null
+    if ($LibraryPath -eq "") {
+        $mlzTempPath = Join-Path -Path (Get-Location) -ChildPath "temp_mlz"
+        $LibraryPath = $mlzTempPath
+        if (Test-Path $LibraryPath) {
+            Write-ModernStatus -Message "Removing existing temp_mlz folder..." -Status "processing" -Indent 2
+            Remove-Item -Path $LibraryPath -Recurse -Force
+        }
+        # missionlz has no usable release tag - its only tag predates the current src/policies content
+        # - so the default branch is cloned.
+        Write-ModernStatus -Message "Cloning Mission Landing Zone repository..." -Status "processing" -Indent 2
+        git clone --config advice.detachedHead=false --depth 1 https://github.com/Azure/missionlz.git $LibraryPath
+        if ($LASTEXITCODE -eq 0) {
+            Write-ModernStatus -Message "Repository cloned successfully" -Status "success" -Indent 4
+        }
+        else {
+            Write-ModernStatus -Message "Failed to clone repository" -Status "error" -Indent 4
+            exit 1
+        }
+    }
+
+    $mlzPolicyPath = Join-Path -Path $LibraryPath -ChildPath "src/policies"
+    if (-not (Test-Path -Path $mlzPolicyPath)) {
+        Write-ModernStatus -Message "Could not find 'src/policies' in '$LibraryPath' - is this a Mission Landing Zone repository?" -Status "error" -Indent 2
+        exit 1
+    }
+    #endregion Source repository
+
+    try {
+        #region Structure file
+        try {
+            $structureFilePath = Get-ChildItem -Path $structureDirectory -Filter "*.$PacEnvironmentSelector.jsonc" -Recurse |
+                Where-Object { $_.Name -match "mlz.policy_default_structure" } | Select-Object -First 1
+            $structureFile = Get-Content -Path $structureFilePath.FullName -Raw -ErrorAction Stop | ConvertFrom-Json
+            Write-ModernStatus -Message "Policy default structure file: $structureFilePath" -Status "info" -Indent 2
+        }
+        catch {
+            Write-ModernStatus -Message "Error reading the policy default structure file: $($_.Exception.Message)" -Status "error" -Indent 2
+            Write-ModernStatus -Message "Please run New-ALZPolicyDefaultStructure.ps1 -Type MLZ first" -Status "warning" -Indent 2
+            exit 1
+        }
+
+        # Flatten the structure file stubs into assignment name -> parameter name -> value. Both the
+        # schema's array form and the object form emitted for the other types are accepted so hand
+        # edited files in either style keep working.
+        $mlzStubValues = @{}
+        $mlzEmptyStubNames = [System.Collections.Generic.List[string]]::new()
+        foreach ($stub in $structureFile.defaultParameterValues.PSObject.Properties) {
+            foreach ($entry in @($stub.Value)) {
+                foreach ($parameter in @($entry.parameters)) {
+                    if ([string]::IsNullOrWhiteSpace("$($parameter.value)") -and -not $mlzEmptyStubNames.Contains($stub.Name)) {
+                        $mlzEmptyStubNames.Add($stub.Name)
+                    }
+                    foreach ($assignmentName in @($entry.policy_assignment_name)) {
+                        if (-not $mlzStubValues.ContainsKey($assignmentName)) {
+                            $mlzStubValues[$assignmentName] = [ordered]@{}
+                        }
+                        $mlzStubValues[$assignmentName][$parameter.parameter_name] = $parameter.value
+                    }
+                }
+            }
+        }
+        #endregion Structure file
+
+        # These two only exist on the CMMC assignment in Azure commercial.
+        $mlzCommercialOnlyParameters = @(
+            "MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f"
+            "MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7"
+        )
+
+        $mlzBaselines = @(
+            [ordered]@{
+                name          = "CMMC"
+                displayName   = "CMMC Level 3"
+                description   = "Mission Landing Zone CMMC Level 3 baseline."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/b5629c75-5c77-4422-87b9-2509e680f8de"
+                parameterFile = "CMMC-policyAssignmentParameters.json"
+            }
+            [ordered]@{
+                name          = "IL5"
+                displayName   = "DoD Impact Level 5"
+                description   = "Mission Landing Zone DoD Impact Level 5 baseline. Not available in Azure commercial, where NIST SP 800-53 Rev. 4 is assigned instead."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/f9a961fa-3241-4b20-adc4-bbf8ad9d7197"
+                parameterFile = "IL5-policyAssignmentParameters.json"
+            }
+            [ordered]@{
+                name          = "NISTRev4"
+                displayName   = "NIST SP 800-53 Rev. 4"
+                description   = "Mission Landing Zone NIST SP 800-53 Rev. 4 baseline."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/cf25b9c1-bd23-4eb6-bd2c-f4f3ac644a5f"
+                parameterFile = "NISTRev4-policyAssignmentParameters.json"
+            }
+            [ordered]@{
+                name          = "NISTRev5"
+                displayName   = "NIST SP 800-53 Rev. 5"
+                description   = "Mission Landing Zone NIST SP 800-53 Rev. 5 baseline."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/179d1daa-458f-4e47-8086-2a68d0d6c38f"
+                parameterFile = "NISTRev5-policyAssignmentParameters.json"
+            }
+            [ordered]@{
+                name          = "Deploy-VMSS-Agents"
+                displayName   = "Deploy VMSS Agents"
+                description   = "Mission Landing Zone virtual machine scale set monitoring agent deployment."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/75714362-cae7-409e-9b99-a8e5075b7fad"
+                parameterFile = $null
+            }
+            [ordered]@{
+                name          = "Deploy-VM-Agents"
+                displayName   = "Deploy VM Agents"
+                description   = "Mission Landing Zone virtual machine monitoring agent deployment."
+                policySetId   = "/providers/Microsoft.Authorization/policySetDefinitions/55f3eceb-5573-4f18-9695-226972c6d74a"
+                parameterFile = $null
+            }
+        )
+
+        if ($mlzIsCommercialCloud) {
+            Write-ModernStatus -Message "IL5 is skipped in Azure commercial - the deployment maps it to NIST SP 800-53 Rev. 4, which is generated as NISTRev4.jsonc" -Status "warning" -Indent 2
+            $mlzBaselines = $mlzBaselines | Where-Object { $_.name -ne "IL5" }
+        }
+
+        Write-ModernSection -Title "Creating Policy Assignment Objects" -Indent 0
+
+        $mlzAssignmentRoot = "$DefinitionsRootFolder/policyAssignments/MLZ/$PacEnvironmentSelector"
+        $mlzExistingAssignmentPaths = @(Get-ChildItem -Path $mlzAssignmentRoot -Recurse -File -Include *.jsonc -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName })
+        $mlzCreatedAssignmentPaths = [System.Collections.Generic.List[string]]::new()
+        $mlzPlaceholderScopes = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($scopeMapping in $structureFile.managementGroupNameMappings.PSObject.Properties) {
+            $scopeValues = @($scopeMapping.Value.value)
+            if ($scopeValues -contains "/subscriptions/00000000-0000-0000-0000-000000000000") {
+                $mlzPlaceholderScopes.Add($scopeMapping.Name)
+            }
+
+            $nodeNamePrefix = $scopeMapping.Value.management_group_function
+            if ([string]::IsNullOrWhiteSpace($nodeNamePrefix)) {
+                $nodeNamePrefix = $scopeMapping.Name
+            }
+            $folderName = ($nodeNamePrefix -replace '[\\/:*?"<>|]', '-')
+            $outputFolder = Join-Path -Path $mlzAssignmentRoot -ChildPath $folderName
+
+            foreach ($baseline in $mlzBaselines) {
+                $parameters = [ordered]@{}
+
+                if ($baseline.parameterFile) {
+                    $parameterFilePath = Join-Path -Path $mlzPolicyPath -ChildPath $baseline.parameterFile
+                    if (-not (Test-Path -Path $parameterFilePath)) {
+                        Write-ModernStatus -Message "Parameter file '$($baseline.parameterFile)' was not found - skipping $($baseline.name)" -Status "warning" -Indent 2
+                        continue
+                    }
+                    # missionlz stores parameters as { "name": { "value": x } }; EPAC assignments
+                    # take { "name": x }.
+                    $sourceParameters = Get-Content -Path $parameterFilePath -Raw | ConvertFrom-Json
+                    foreach ($sourceParameter in $sourceParameters.PSObject.Properties) {
+                        $parameters[$sourceParameter.Name] = $sourceParameter.Value.value
+                    }
+                }
+
+                if ($mlzStubValues.ContainsKey($baseline.name)) {
+                    foreach ($parameterName in $mlzStubValues[$baseline.name].Keys) {
+                        if (-not $mlzIsCommercialCloud -and $parameterName -in $mlzCommercialOnlyParameters) {
+                            continue
+                        }
+                        $parameters[$parameterName] = $mlzStubValues[$baseline.name][$parameterName]
+                    }
+                }
+
+                $baseTemplate = [ordered]@{
+                    '$schema'       = "https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-assignment-schema.json"
+                    nodeName        = "$nodeNamePrefix/$($baseline.name)"
+                    assignment      = [ordered]@{
+                        name        = $baseline.name
+                        displayName = $baseline.displayName
+                        description = $baseline.description
+                    }
+                    definitionEntry = [ordered]@{
+                        displayName = $baseline.displayName
+                        policySetId = $baseline.policySetId
+                    }
+                    enforcementMode = $structureFile.enforcementMode
+                    parameters      = $parameters
+                    scope           = [ordered]@{
+                        $PacEnvironmentSelector = $scopeValues
+                    }
+                }
+
+                $outputPath = Join-Path -Path $outputFolder -ChildPath "$($baseline.name).jsonc"
+                $null = New-Item -Path $outputFolder -ItemType Directory -Force
+                ($baseTemplate | ConvertTo-Json -Depth 50) | Set-Content -Path $outputPath -Encoding utf8 -Force
+                $mlzCreatedAssignmentPaths.Add((Get-Item -Path $outputPath).FullName)
+                Write-ModernStatus -Message "Created assignment '$($baseline.name)' with $($parameters.Count) parameters" -Status "success" -Indent 2
+            }
+        }
+
+        # Remove assignments that were not created in this run - this is what removes a previously
+        # generated IL5.jsonc when the PAC environment moves to Azure commercial.
+        foreach ($existingPath in $mlzExistingAssignmentPaths) {
+            if ($existingPath -notin $mlzCreatedAssignmentPaths) {
+                Remove-Item -Path $existingPath -Force -ErrorAction SilentlyContinue
+                Write-ModernStatus -Message "Removed '$existingPath' as it is no longer generated for this cloud" -Status "info" -Indent 2
+            }
+        }
+
+        foreach ($placeholderScope in $mlzPlaceholderScopes) {
+            Write-ModernStatus -Message "Scope '$placeholderScope' is still the placeholder subscription id - update the structure file before deploying" -Status "warning" -Indent 2
+        }
+        foreach ($emptyStubName in $mlzEmptyStubNames) {
+            Write-ModernStatus -Message "Structure file value '$emptyStubName' is empty - populate it before deploying" -Status "warning" -Indent 2
+        }
+
+        Write-ModernStatus -Message "MLZ Policy sync completed successfully" -Status "success" -Indent 0
+    }
+    finally {
+        if ($mlzTempPath -and $LibraryPath -eq $mlzTempPath) {
+            Remove-Item -Path $LibraryPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    return
+}
+#endregion MLZ
 
 if (-not($SyncAssignmentsOnly) -and $Type -ne "SLZ") {
     Write-ModernSection -Title "Creating Policy Definition Objects" -Indent 0

--- a/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.MLZ.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.MLZ.Tests.ps1
@@ -1,0 +1,92 @@
+BeforeAll {
+    $script:StructureScriptPath = Join-Path $PSScriptRoot '../../../Scripts/CloudAdoptionFramework/New-ALZPolicyDefaultStructure.ps1'
+    $script:SchemaPath = Join-Path $PSScriptRoot '../../../Schemas/policy-structure-schema.json'
+
+    function Invoke-MlzStructureScript {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $DefinitionsRoot,
+
+            [string] $PacEnvironmentSelector = 'epac-dev',
+
+            [Parameter(Mandatory = $true)]
+            [string] $WorkingDirectory
+        )
+
+        $runnerPath = Join-Path $WorkingDirectory 'run-structure.ps1'
+        Set-Content -Path $runnerPath -Value @"
+Set-Location '$($WorkingDirectory.Replace("'", "''"))'
+& '$($script:StructureScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($DefinitionsRoot.Replace("'", "''"))' -Type MLZ -PacEnvironmentSelector '$($PacEnvironmentSelector.Replace("'", "''"))'
+"@
+
+        & pwsh -NoLogo -NoProfile -File $runnerPath | Out-Null
+        return $LASTEXITCODE
+    }
+}
+
+Describe 'New-ALZPolicyDefaultStructure MLZ' {
+    It 'creates a Mission Landing Zone structure file with a subscription scope placeholder' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions'
+        $workingDirectory = Join-Path $TestDrive 'work'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -WorkingDirectory $workingDirectory | Should -Be 0
+
+        $structureFile = Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.epac-dev.jsonc'
+        Test-Path $structureFile | Should -BeTrue
+
+        $structure = Get-Content -Path $structureFile -Raw | ConvertFrom-Json
+
+        $structure.'$schema' | Should -Be 'https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-structure-schema.json'
+        $structure.enforcementMode | Should -Be 'Default'
+
+        @($structure.managementGroupNameMappings.PSObject.Properties.Name) | Should -Be @('mlz')
+        $structure.managementGroupNameMappings.mlz.management_group_function | Should -Be 'Mission Landing Zone'
+        $structure.managementGroupNameMappings.mlz.value | Should -Be '/subscriptions/00000000-0000-0000-0000-000000000000'
+    }
+
+    It 'stubs defaultParameterValues so they are populated during the sync step' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions-defaults'
+        $workingDirectory = Join-Path $TestDrive 'work-defaults'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -WorkingDirectory $workingDirectory | Should -Be 0
+
+        $structure = Get-Content -Path (Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.epac-dev.jsonc') -Raw | ConvertFrom-Json
+
+        @($structure.defaultParameterValues.PSObject.Properties).Count | Should -Be 0
+        @($structure.enforceGuardrails.deployments).Count | Should -Be 0
+        $structure.PSObject.Properties.Name | Should -Not -Contain 'archetypeScopeMappings'
+    }
+
+    It 'produces a structure file that validates against the policy structure schema' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions-schema'
+        $workingDirectory = Join-Path $TestDrive 'work-schema'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -WorkingDirectory $workingDirectory | Should -Be 0
+
+        $structureContent = Get-Content -Path (Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.epac-dev.jsonc') -Raw
+        $structureContent | Test-Json -SchemaFile $script:SchemaPath | Should -BeTrue
+    }
+
+    It 'does not clone a library repository because MLZ needs no library content' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions-noclone'
+        $workingDirectory = Join-Path $TestDrive 'work-noclone'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -WorkingDirectory $workingDirectory | Should -Be 0
+
+        Test-Path (Join-Path $workingDirectory 'temp') | Should -BeFalse
+    }
+
+    It 'honours the PAC environment selector in the output file name' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions-env'
+        $workingDirectory = Join-Path $TestDrive 'work-env'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -PacEnvironmentSelector 'tenant1' -WorkingDirectory $workingDirectory | Should -Be 0
+
+        Test-Path (Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.tenant1.jsonc') | Should -BeTrue
+    }
+}

--- a/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.MLZ.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/New-ALZPolicyDefaultStructure.MLZ.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'New-ALZPolicyDefaultStructure MLZ' {
         $structure.managementGroupNameMappings.mlz.value | Should -Be '/subscriptions/00000000-0000-0000-0000-000000000000'
     }
 
-    It 'stubs defaultParameterValues so they are populated during the sync step' {
+    It 'stubs the deployment time parameters that cannot be sourced from the missionlz repository' {
         $definitionsRoot = Join-Path $TestDrive 'Definitions-defaults'
         $workingDirectory = Join-Path $TestDrive 'work-defaults'
         New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
@@ -54,9 +54,49 @@ Describe 'New-ALZPolicyDefaultStructure MLZ' {
 
         $structure = Get-Content -Path (Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.epac-dev.jsonc') -Raw | ConvertFrom-Json
 
-        @($structure.defaultParameterValues.PSObject.Properties).Count | Should -Be 0
+        $defaults = $structure.defaultParameterValues
+        @($defaults.PSObject.Properties.Name) | Should -Be @(
+            'log_analytics_workspace_resource_id'
+            'log_analytics_workspace_customer_id'
+            'windows_administrators_group_membership'
+            'windows_administrators_group_exclusions'
+        )
+
+        # Each stub is an array so a single value can fan out to the differently named parameter
+        # that each baseline uses for it.
+        foreach ($stubName in $defaults.PSObject.Properties.Name) {
+            $defaults.$stubName | Should -BeOfType ([System.Management.Automation.PSCustomObject])
+            @($defaults.$stubName).Count | Should -BeGreaterThan 0
+        }
+
+        $lawStub = @($defaults.log_analytics_workspace_resource_id)
+        $lawStub.Count | Should -Be 3
+        @($lawStub.parameters.parameter_name) | Should -Be @(
+            'logAnalyticsWorkspaceIdforVMReporting'
+            'logAnalyticsWorkspaceIDForVMAgents'
+            'logAnalytics_1'
+        )
+        @($lawStub[2].policy_assignment_name) | Should -Be @('Deploy-VMSS-Agents', 'Deploy-VM-Agents')
+
+        # Everything except the commercial only exclusion is left empty for the user to populate.
+        @($lawStub.parameters.value) | Should -Be @('', '', '')
+        @($defaults.windows_administrators_group_exclusions)[0].parameters.value | Should -Be 'admin'
+
         @($structure.enforceGuardrails.deployments).Count | Should -Be 0
         $structure.PSObject.Properties.Name | Should -Not -Contain 'archetypeScopeMappings'
+    }
+
+    It 'does not stub the baseline parameter values that come from the missionlz repository' {
+        $definitionsRoot = Join-Path $TestDrive 'Definitions-nobaseline'
+        $workingDirectory = Join-Path $TestDrive 'work-nobaseline'
+        New-Item -ItemType Directory -Path $definitionsRoot, $workingDirectory -Force | Out-Null
+
+        Invoke-MlzStructureScript -DefinitionsRoot $definitionsRoot -WorkingDirectory $workingDirectory | Should -Be 0
+
+        $structure = Get-Content -Path (Join-Path $definitionsRoot 'policyStructures/mlz.policy_default_structure.epac-dev.jsonc') -Raw | ConvertFrom-Json
+
+        # The baselines carry several hundred parameters between them; none of them belong in the structure file.
+        @($structure.defaultParameterValues.PSObject.Properties).Count | Should -BeLessThan 10
     }
 
     It 'produces a structure file that validates against the policy structure schema' {

--- a/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.MLZ.Tests.ps1
+++ b/Tests/CloudAdoptionFramework/Unit/Sync-ALZPolicyFromLibrary.MLZ.Tests.ps1
@@ -1,0 +1,276 @@
+BeforeAll {
+    $script:SyncScriptPath = (Resolve-Path (Join-Path $PSScriptRoot '../../../Scripts/CloudAdoptionFramework/Sync-ALZPolicyFromLibrary.ps1')).Path
+
+    # Builds a minimal Definitions tree plus a fake missionlz checkout so the sync never needs the
+    # network. Returns the paths the tests assert against.
+    function New-MlzFixture {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Root,
+
+            [Parameter(Mandatory = $true)]
+            [string] $Cloud,
+
+            [Parameter(Mandatory = $true)]
+            [string] $PacEnvironmentSelector,
+
+            [string] $LogAnalyticsResourceId = '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/law',
+
+            [string] $Scope = '/subscriptions/22222222-2222-2222-2222-222222222222'
+        )
+
+        $definitionsRoot = Join-Path $Root 'Definitions'
+        $libraryRoot = Join-Path $Root 'missionlz'
+
+        foreach ($path in @(
+                (Join-Path $definitionsRoot 'policyStructures')
+                (Join-Path $definitionsRoot 'policyAssignments')
+                (Join-Path $libraryRoot 'src/policies')
+            )) {
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+        }
+
+        Set-Content -Path (Join-Path $definitionsRoot 'global-settings.jsonc') -Value @"
+{
+  "telemetryOptOut": true,
+  "pacEnvironments": [
+    {
+      "pacSelector": "$PacEnvironmentSelector",
+      "cloud": "$Cloud",
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "deploymentRootScope": "$Scope"
+    }
+  ]
+}
+"@
+
+        # missionlz stores parameters as { "name": { "value": x } }.
+        Set-Content -Path (Join-Path $libraryRoot 'src/policies/CMMC-policyAssignmentParameters.json') -Value '{ "cmmcOnly": { "value": "cmmc" }, "IncludeArcMachines": { "value": false } }'
+        Set-Content -Path (Join-Path $libraryRoot 'src/policies/IL5-policyAssignmentParameters.json') -Value '{ "il5Only": { "value": 5 } }'
+        Set-Content -Path (Join-Path $libraryRoot 'src/policies/NISTRev4-policyAssignmentParameters.json') -Value '{ "nist4Only": { "value": true } }'
+        Set-Content -Path (Join-Path $libraryRoot 'src/policies/NISTRev5-policyAssignmentParameters.json') -Value '{ "nist5Only": { "value": ["a", "b"] } }'
+
+        Set-Content -Path (Join-Path $definitionsRoot "policyStructures/mlz.policy_default_structure.$PacEnvironmentSelector.jsonc") -Value @"
+{
+  "managementGroupNameMappings": {
+    "mlz": {
+      "management_group_function": "Mission Landing Zone",
+      "value": "$Scope"
+    }
+  },
+  "enforcementMode": "DoNotEnforce",
+  "defaultParameterValues": {
+    "log_analytics_workspace_resource_id": [
+      {
+        "policy_assignment_name": "NISTRev4",
+        "parameters": { "parameter_name": "logAnalyticsWorkspaceIdforVMReporting", "value": "$LogAnalyticsResourceId" }
+      },
+      {
+        "policy_assignment_name": "IL5",
+        "parameters": { "parameter_name": "logAnalyticsWorkspaceIDForVMAgents", "value": "$LogAnalyticsResourceId" }
+      },
+      {
+        "policy_assignment_name": ["Deploy-VMSS-Agents", "Deploy-VM-Agents"],
+        "parameters": { "parameter_name": "logAnalytics_1", "value": "$LogAnalyticsResourceId" }
+      }
+    ],
+    "log_analytics_workspace_customer_id": [
+      {
+        "policy_assignment_name": "CMMC",
+        "parameters": { "parameter_name": "logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917", "value": "33333333-3333-3333-3333-333333333333" }
+      }
+    ],
+    "windows_administrators_group_membership": [
+      {
+        "policy_assignment_name": "NISTRev4",
+        "parameters": { "parameter_name": "listOfMembersToIncludeInWindowsVMAdministratorsGroup", "value": "contoso-admins" }
+      },
+      {
+        "policy_assignment_name": "IL5",
+        "parameters": { "parameter_name": "membersToIncludeInLocalAdministratorsGroup", "value": "contoso-admins" }
+      },
+      {
+        "policy_assignment_name": "CMMC",
+        "parameters": { "parameter_name": "MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7", "value": "contoso-admins" }
+      }
+    ],
+    "windows_administrators_group_exclusions": [
+      {
+        "policy_assignment_name": "CMMC",
+        "parameters": { "parameter_name": "MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f", "value": "admin" }
+      }
+    ]
+  },
+  "enforceGuardrails": {
+    "deployments": []
+  }
+}
+"@
+
+        [pscustomobject]@{
+            DefinitionsRoot = $definitionsRoot
+            LibraryRoot     = $libraryRoot
+            AssignmentRoot  = Join-Path $definitionsRoot "policyAssignments/MLZ/$PacEnvironmentSelector/Mission Landing Zone"
+        }
+    }
+
+    function Invoke-MlzSync {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Root,
+
+            [Parameter(Mandatory = $true)]
+            [string] $DefinitionsRoot,
+
+            [Parameter(Mandatory = $true)]
+            [string] $LibraryRoot,
+
+            [Parameter(Mandatory = $true)]
+            [string] $PacEnvironmentSelector
+        )
+
+        $helperScriptPath = Join-Path $Root 'run-mlz-sync.ps1'
+        Set-Content -Path $helperScriptPath -Value @"
+& '$($script:SyncScriptPath.Replace("'", "''"))' -DefinitionsRootFolder '$($DefinitionsRoot.Replace("'", "''"))' -LibraryPath '$($LibraryRoot.Replace("'", "''"))' -Type MLZ -PacEnvironmentSelector '$PacEnvironmentSelector'
+# Propagate the sync script's exit code so the caller can assert on failures.
+if (`$LASTEXITCODE) { exit `$LASTEXITCODE }
+"@
+
+        & pwsh -NoLogo -NoProfile -File $helperScriptPath | Out-Null
+        return $LASTEXITCODE
+    }
+}
+
+Describe 'Sync-ALZPolicyFromLibrary MLZ' {
+    It 'creates every baseline assignment for a non commercial cloud' {
+        $root = Join-Path $TestDrive 'gov'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        @(Get-ChildItem -Path $fixture.AssignmentRoot -File | Select-Object -ExpandProperty Name | Sort-Object) | Should -Be @(
+            'CMMC.jsonc'
+            'Deploy-VM-Agents.jsonc'
+            'Deploy-VMSS-Agents.jsonc'
+            'IL5.jsonc'
+            'NISTRev4.jsonc'
+            'NISTRev5.jsonc'
+        )
+
+        $nist5 = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'NISTRev5.jsonc') -Raw | ConvertFrom-Json
+        $nist5.assignment.name | Should -Be 'NISTRev5'
+        $nist5.definitionEntry.policySetId | Should -Be '/providers/Microsoft.Authorization/policySetDefinitions/179d1daa-458f-4e47-8086-2a68d0d6c38f'
+        # enforcementMode comes from the structure file, and the missionlz {"value":x} wrapper is flattened.
+        $nist5.enforcementMode | Should -Be 'DoNotEnforce'
+        $nist5.parameters.nist5Only | Should -Be @('a', 'b')
+        $nist5.scope.'epac-dev' | Should -Be '/subscriptions/22222222-2222-2222-2222-222222222222'
+    }
+
+    It 'applies the structure file stubs to the assignments that need them' {
+        $root = Join-Path $TestDrive 'stubs'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        $lawResourceId = '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/law'
+
+        $nist4 = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'NISTRev4.jsonc') -Raw | ConvertFrom-Json
+        $nist4.parameters.logAnalyticsWorkspaceIdforVMReporting | Should -Be $lawResourceId
+        $nist4.parameters.listOfMembersToIncludeInWindowsVMAdministratorsGroup | Should -Be 'contoso-admins'
+        $nist4.parameters.nist4Only | Should -BeTrue
+
+        $il5 = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'IL5.jsonc') -Raw | ConvertFrom-Json
+        $il5.parameters.logAnalyticsWorkspaceIDForVMAgents | Should -Be $lawResourceId
+        $il5.parameters.membersToIncludeInLocalAdministratorsGroup | Should -Be 'contoso-admins'
+
+        # A single stub fans out to both agent assignments.
+        foreach ($agentAssignment in @('Deploy-VM-Agents', 'Deploy-VMSS-Agents')) {
+            $agent = Get-Content -Path (Join-Path $fixture.AssignmentRoot "$agentAssignment.jsonc") -Raw | ConvertFrom-Json
+            $agent.parameters.logAnalytics_1 | Should -Be $lawResourceId
+            @($agent.parameters.PSObject.Properties).Count | Should -Be 1
+        }
+
+        # The CMMC workspace parameter takes the customer id, not the resource id.
+        $cmmc = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'CMMC.jsonc') -Raw | ConvertFrom-Json
+        $cmmc.parameters.'logAnalyticsWorkspaceId-f47b5582-33ec-4c5c-87c0-b010a6b2e917' | Should -Be '33333333-3333-3333-3333-333333333333'
+    }
+
+    It 'omits the commercial only CMMC parameters outside of Azure commercial' {
+        $root = Join-Path $TestDrive 'gov-cmmc'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        $cmmc = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'CMMC.jsonc') -Raw | ConvertFrom-Json
+        $cmmc.parameters.PSObject.Properties.Name | Should -Not -Contain 'MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f'
+        $cmmc.parameters.PSObject.Properties.Name | Should -Not -Contain 'MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7'
+    }
+
+    It 'skips IL5 and adds the CMMC administrators group parameters in Azure commercial' {
+        $root = Join-Path $TestDrive 'com'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureCloud' -PacEnvironmentSelector 'epac-dev'
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        # The deployment maps IL5 to NISTRev4 in commercial, which is already generated in its own right.
+        @(Get-ChildItem -Path $fixture.AssignmentRoot -File | Select-Object -ExpandProperty Name | Sort-Object) | Should -Be @(
+            'CMMC.jsonc'
+            'Deploy-VM-Agents.jsonc'
+            'Deploy-VMSS-Agents.jsonc'
+            'NISTRev4.jsonc'
+            'NISTRev5.jsonc'
+        )
+
+        $cmmc = Get-Content -Path (Join-Path $fixture.AssignmentRoot 'CMMC.jsonc') -Raw | ConvertFrom-Json
+        $cmmc.parameters.'MembersToExclude-69bf4abd-ca1e-4cf6-8b5a-762d42e61d4f' | Should -Be 'admin'
+        $cmmc.parameters.'MembersToInclude-30f71ea1-ac77-4f26-9fc5-2d926bbd4ba7' | Should -Be 'contoso-admins'
+    }
+
+    It 'removes assignments that are no longer generated when the cloud changes' {
+        $root = Join-Path $TestDrive 'cleanup'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+        Test-Path (Join-Path $fixture.AssignmentRoot 'IL5.jsonc') | Should -BeTrue
+
+        $globalSettingsPath = Join-Path $fixture.DefinitionsRoot 'global-settings.jsonc'
+        (Get-Content -Path $globalSettingsPath -Raw).Replace('AzureUSGovernment', 'AzureCloud') | Set-Content -Path $globalSettingsPath
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+        Test-Path (Join-Path $fixture.AssignmentRoot 'IL5.jsonc') | Should -BeFalse
+        Test-Path (Join-Path $fixture.AssignmentRoot 'NISTRev4.jsonc') | Should -BeTrue
+    }
+
+    It 'produces assignments that validate against the policy assignment schema' {
+        $root = Join-Path $TestDrive 'schema'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+        $schemaPath = (Resolve-Path (Join-Path $PSScriptRoot '../../../Schemas/policy-assignment-schema.json')).Path
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        foreach ($assignmentFile in Get-ChildItem -Path $fixture.AssignmentRoot -File) {
+            (Get-Content -Path $assignmentFile.FullName -Raw | Test-Json -SchemaFile $schemaPath) | Should -BeTrue -Because "$($assignmentFile.Name) must be a valid EPAC policy assignment"
+        }
+    }
+
+    It 'falls back to Azure commercial when the PAC environment cannot be resolved' {
+        $root = Join-Path $TestDrive 'fallback'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+
+        # The structure file selector still matches, but no PAC environment does.
+        $globalSettingsPath = Join-Path $fixture.DefinitionsRoot 'global-settings.jsonc'
+        (Get-Content -Path $globalSettingsPath -Raw).Replace('"pacSelector": "epac-dev"', '"pacSelector": "something-else"') | Set-Content -Path $globalSettingsPath
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 0
+
+        Test-Path (Join-Path $fixture.AssignmentRoot 'IL5.jsonc') | Should -BeFalse
+    }
+
+    It 'fails when the library path is not a missionlz repository' {
+        $root = Join-Path $TestDrive 'bad-library'
+        $fixture = New-MlzFixture -Root $root -Cloud 'AzureUSGovernment' -PacEnvironmentSelector 'epac-dev'
+        Remove-Item -Path (Join-Path $fixture.LibraryRoot 'src/policies') -Recurse -Force
+
+        Invoke-MlzSync -Root $root -DefinitionsRoot $fixture.DefinitionsRoot -LibraryRoot $fixture.LibraryRoot -PacEnvironmentSelector 'epac-dev' | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Why

Teams deploying [Azure/missionlz](https://github.com/Azure/missionlz) (Mission Landing Zone) currently have no way to bring its policy assignments into EPAC. The missionlz repo stores its assignment parameters as plain JSON files under `src/policies`, with no custom policy or policy set definitions and no library-style metadata, so none of the existing `ALZ`/`AMBA`/`FSI`/`SLZ` tooling can read it.

This adds `MLZ` as a first-class type to both CloudAdoptionFramework cmdlets.

## Approach

Because the missionlz layout has nothing in common with the Azure Landing Zones Library, both cmdlets get a **fully separate code path** that returns before any library machinery runs. Nothing on the existing ALZ/AMBA/FSI/SLZ paths was refactored or shared.

**`New-ALZPolicyDefaultStructure -Type MLZ`** emits a structure file with subscription-scoped management group name mappings and four `defaultParameterValues` stubs, rather than the hundreds of parameters the baselines actually carry. The stubs fan out to the correctly-named parameter in each baseline at sync time:

| Stub | Fans out to |
| --- | --- |
| `log_analytics_workspace_resource_id` | `logAnalyticsWorkspaceIdforVMReporting` (NISTRev4), `logAnalyticsWorkspaceIDForVMAgents` (IL5), `logAnalytics_1` (both agent assignments) |
| `log_analytics_workspace_customer_id` | `logAnalyticsWorkspaceId-f47b5582-...` (CMMC, a workspace customer ID GUID rather than a resource ID) |
| `windows_administrators_group_membership` | three differently-named parameters across baselines |
| `windows_administrators_group_exclusions` | `MembersToExclude-69bf4abd-...`, pre-filled with `admin` |

**`Sync-ALZPolicyFromLibrary -Type MLZ`** shallow-clones `Azure/missionlz`, flattens each `src/policies/*.json` from `{ "name": { "value": v } }` into EPAC's `{ "name": v }`, and writes six assignment files (CMMC, IL5, NISTRev4, NISTRev5, Deploy-VMSS-Agents, Deploy-VM-Agents) under `Definitions/policyAssignments/MLZ/<PacEnvironmentSelector>/<management_group_function>/`. Every initiative is built-in, so the definition and set-definition sync is skipped entirely.

Cloud-conditional behaviour mirrors `src/modules/policy-assignment.bicep` and is driven by the `cloud` value on the matching pacEnvironment in `global-settings.jsonc` rather than a new parameter. On `AzureCloud`, IL5 is skipped (the bicep maps it to NISTRev4) and CMMC gains two extra membership parameters.

### Upstream change detection

Also adds `.github/workflows/check-mlz-policy-changes.yaml`, the MLZ counterpart to `check-alz-release.yaml`. missionlz does not publish releases on a cadence, so a release check is not usable; this watches daily for commits to `src/policies` and `src/modules/policy-assignment.bicep` on the default branch and raises an issue listing them with a checklist of what to re-verify in the sync scripts. Repeat detections comment on the existing open issue rather than opening a new one each day.

## Things worth a careful look

- **No tag pinning.** The only missionlz tag (`v1.0.0`) predates the current `src/policies` content, so the MLZ path tracks the default branch. Output can therefore drift with upstream, which is what the new detection workflow above is there to surface.
- **Stale-file cleanup compares full paths**, not file names as the ALZ path does. This is what removes a previously generated `IL5.jsonc` when the pacEnvironment cloud flips to `AzureCloud`.
- **Role assignments and remediation tasks** defined in the missionlz bicep are deliberately not reproduced.
- **All six baselines are generated** so users can pick, whereas a real MLZ deployment assigns exactly one per resource group. The docs tell users to delete the files they do not want to avoid overlapping baselines.
- **Minor behaviour change:** passing `-Tag ""` explicitly used to throw via `ValidateScript`. The attribute became a runtime check (so it can be skipped for MLZ), and an empty string now falls through to the type defaults.
- `Schemas/policy-structure-schema.json` was widened so `managementGroupNameMappings.*.value` accepts `/subscriptions/<guid>`, which MLZ needs.

## Verification

- 23/23 `Tests/CloudAdoptionFramework` Pester tests pass, including 6 new structure tests and 8 new sync tests covering both clouds, stub fan-out, stale cleanup on cloud flip, schema validity and error paths.
- Live end-to-end run against the real missionlz repo produced 134/167/8/5/1/1 parameters across the six assignments, all validating against `policy-assignment-schema.json`.
- **ALZ regression proven clean:** the `main` version and this version of the sync script were run against the same ALZ library clone from a shared seeded structure file, and all 262 output files compared semantically with zero differences. (The comparison has to be semantic because the generator emits `parameters` from an unordered hashtable, so key order already differs between any two process invocations.)
- The new workflow's detection step was extracted and executed locally against the live missionlz API: a wide lookback window correctly reported the one real commit touching both watched paths, a 25 hour window correctly reported no change, and the issue dedupe search was proven to match an existing open issue title.
