### PR TITLE
fix: correct typo in documentPolicySets example comment

### DIFF
--- a/Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc
+++ b/Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc
@@ -6,7 +6,7 @@
             "fileNameStem": "MyPolicySets",
             "title": "My Policy Sets",
 			"includePolicySetList": true, // Set to false if you do not want the PolicySet List
-            "policySetEffectsOneColumn": false, //Set to true if you want just 1 column showing the effects per PolicySet, usefull if larger number of (custom) PolicySet are defined.
+            "policySetEffectsOneColumn": false, //Set to true if you want just 1 column showing the effects per PolicySet, useful if larger number of (custom) PolicySet are defined.
             "policySets": [
                 {
                     "shortName": "Azure Security Benchmark v3",


### PR DESCRIPTION
Spelling correction in an example configuration comment.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `Examples/Auto-Documentation/policyDocumentations/documentPolicySets.jsonc` | 9 | `usefull` | `useful` |

The word sits inside the `//` comment that documents `policySetEffectsOneColumn`, starting at
column 123 where the comment begins at column 48. No key, value, enum or identifier is
touched, and the file still parses as JSONC.

It is the only occurrence in the repository.
