### PR TITLE
Filter Policy Set role assignments by effect and honour definitionVersion

### DIFF
--- a/Docs/settings-global-setting-file.md
+++ b/Docs/settings-global-setting-file.md
@@ -121,7 +121,7 @@ EPAC has a concept of an environment identified by a string (unique per reposito
 |-----------|-------------|
 | `globalNotScopes` | See [Excluding scopes for all Assignments with `globalNotScopes`](#excluding-scopes-for-all-assignments-with-globalnotscopes) |
 | `skipResourceValidationForExemptions` | Disables checking the resource existence for Policy Exemptions. Default is false. This can be useful if you have a massive amount of exemptions and the validation is taking too long. |
-| `filterRoleAssignmentsByEffect` | Reduces the role assignments created for Policy Set assignments. Default is false. See [Reducing role assignments with `filterRoleAssignmentsByEffect`](#reducing-role-assignments-with-filterroleassignmentsbyeffect). |
+| `filterRoleAssignmentsByEffect` | Reduces the role assignments created for Policy Set assignments. Default is true. See [Reducing role assignments with `filterRoleAssignmentsByEffect`](#reducing-role-assignments-with-filterroleassignmentsbyeffect). |
 | `deployedBy` | Populates the `metadata` fields. It defaults to `epac/$pacOwnerId/$pacSelector`. We recommend to use the default. |
 | `managedTenantId` | Used when the `pacEnvironment` is in a lighthouse managed tenant. |
 | `defaultContext` | In rare cases (typically only when deploying to a lighthouse managed tenant) the default context (Get-azContext) of a user/SPN running a plan will be set to a subscription where that user/SPN does not have sufficient privileges. Some checks have been built in so that in some cases when this happens EPAC is able to fix the context issue. When it is not, a `defaultContext` subscription name must be provided. This can be any subscription within the `deploymentRootScope`. |
@@ -147,14 +147,16 @@ Policies with `Modify` and `DeployIfNotExists` effects require a Managed Identit
 
 ### Reducing role assignments with `filterRoleAssignmentsByEffect`
 
-By default the Managed Identity of a Policy Set assignment is granted the union of the `roleDefinitionIds` of **every** member Policy, whatever effect each member evaluates with. Some built-in Policy Sets hard-code a member's effect to a non-deploying value such as `AuditIfNotExists`, so those members never deploy anything, yet their roles are still granted. Microsoft Cloud Security Benchmark v2 is the most visible example: it grants eight roles, seven of which - including `Contributor`, `User Access Administrator` and `Azure Event Hubs Data Owner` - come only from members hard-coded to `AuditIfNotExists`.
+The Managed Identity of a Policy Set assignment can be granted the union of the `roleDefinitionIds` of **every** member Policy, whatever effect each member evaluates with. Some built-in Policy Sets hard-code a member's effect to a non-deploying value such as `AuditIfNotExists`, so those members never deploy anything, yet their roles are still granted. Microsoft Cloud Security Benchmark v2 is the most visible example: it would grant eight roles, seven of which - including `Contributor`, `User Access Administrator` and `Azure Event Hubs Data Owner` - come only from members hard-coded to `AuditIfNotExists`.
 
-Setting `filterRoleAssignmentsByEffect` to `true` omits a role when it is **only** contributed by member Policies whose effect the Policy Set hard-codes to a literal, non-deploying effect: `Audit`, `AuditIfNotExists`, `Deny`, `DenyAction`, `Disabled`, `Append`, `Manual` or `AddToNetworkGroup`.
+`filterRoleAssignmentsByEffect` defaults to `true`, which omits a role when it is **only** contributed by member Policies whose effect the Policy Set hard-codes to a literal, non-deploying effect: `Audit`, `AuditIfNotExists`, `Deny`, `DenyAction`, `Disabled`, `Append`, `Manual` or `AddToNetworkGroup`.
 
 A Policy Set may also pin a member's effect to an ARM expression, for example `[if(contains(parameters('resourceTypeList'),'microsoft.aad/domainservices'),parameters('effect'),'Disabled')]`. Such an expression is evaluated by Azure at assignment time and can resolve to a deploying effect, so those members always keep their roles. The same applies to any effect value EPAC does not recognise.
 
+Set it to `false` to temporarily restore the previous behaviour of granting the union of all member roles:
+
 ```json
-    "filterRoleAssignmentsByEffect": true,
+    "filterRoleAssignmentsByEffect": false,
 ```
 
 A hard-coded effect is only a default. An assignment may use an [override](policy-assignments.md#defining-overrides-with-json) of kind `policyEffect` to raise a member back to `DeployIfNotExists` or `Modify`, and Azure accepts that even when the Policy Set pins the effect. EPAC therefore keeps the roles of any member an override raises to a deploying effect. Roles are also kept when:
@@ -168,12 +170,16 @@ The setting is deliberately narrow. It does not change:
 - **Policy Sets which do not hard-code effects.** When a member takes its effect from its own definition default or from a Policy Set parameter, it is not hard-coded and its roles are always kept.
 - **`additionalRoleAssignments`.** These are read from the Policy Assignment file and appended after the Policy derived roles are calculated. They never pass through the filter, so they are granted in full at the scope you specify. This is what makes them a reliable way to add back a role the filter removes.
 
+#### Assignments which pin `definitionVersion`
+
+Members and hard-coded member effects change between published versions of a Policy Set. When an assignment pins a `definitionVersion`, EPAC resolves that version from the Policy Set's published version history and calculates the roles from it, rather than from the latest version. Wildcards are resolved to the highest matching version, preferring a stable version and falling back to a pre-release only when no stable version matches the pattern.
+
+This version-aware calculation applies whether or not `filterRoleAssignmentsByEffect` is enabled, so a version-pinned assignment may see its roles change even with filtering off. If the version history cannot be read - a custom Policy Set with no published versions, a cloud which does not expose the endpoint, or a pattern which matches nothing - EPAC falls back to the latest version and keeps every role.
+
 > [!WARNING]
 > This setting narrows the permissions granted to the Managed Identity. The roles it removes are contributed only by members which cannot deploy anything, so remediation is not affected, but the role assignments themselves are deleted from Azure on the next deployment of the roles plan.
 >
-> One case needs care: the roles are calculated from the **latest** version of the Policy Set, not from the version an assignment pins with `definitionVersion` ([#1394](https://github.com/Azure/enterprise-azure-policy-as-code/issues/1394)). If a member deploys in the pinned version but is hard-coded to a non-deploying effect in the latest version, its role is removed even though the running assignment still needs it. Review the roles plan before deploying when your assignments pin `definitionVersion`.
->
-> Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
+> Review the roles plan before deploying. Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
 
 ### Excluding scopes for all Assignments with `globalNotScopes`
 

--- a/Docs/settings-global-setting-file.md
+++ b/Docs/settings-global-setting-file.md
@@ -121,6 +121,7 @@ EPAC has a concept of an environment identified by a string (unique per reposito
 |-----------|-------------|
 | `globalNotScopes` | See [Excluding scopes for all Assignments with `globalNotScopes`](#excluding-scopes-for-all-assignments-with-globalnotscopes) |
 | `skipResourceValidationForExemptions` | Disables checking the resource existence for Policy Exemptions. Default is false. This can be useful if you have a massive amount of exemptions and the validation is taking too long. |
+| `filterRoleAssignmentsByEffect` | Reduces the role assignments created for Policy Set assignments. Default is false. See [Reducing role assignments with `filterRoleAssignmentsByEffect`](#reducing-role-assignments-with-filterroleassignmentsbyeffect). |
 | `deployedBy` | Populates the `metadata` fields. It defaults to `epac/$pacOwnerId/$pacSelector`. We recommend to use the default. |
 | `managedTenantId` | Used when the `pacEnvironment` is in a lighthouse managed tenant. |
 | `defaultContext` | In rare cases (typically only when deploying to a lighthouse managed tenant) the default context (Get-azContext) of a user/SPN running a plan will be set to a subscription where that user/SPN does not have sufficient privileges. Some checks have been built in so that in some cases when this happens EPAC is able to fix the context issue. When it is not, a `defaultContext` subscription name must be provided. This can be any subscription within the `deploymentRootScope`. |
@@ -143,6 +144,24 @@ Policies with `Modify` and `DeployIfNotExists` effects require a Managed Identit
         "*": "eastus2"
     },
 ```
+
+### Reducing role assignments with `filterRoleAssignmentsByEffect`
+
+By default the Managed Identity of a Policy Set assignment is granted the union of the `roleDefinitionIds` of **every** member Policy, whatever effect each member evaluates with. Some built-in Policy Sets hard-code a member's effect to a non-deploying value such as `AuditIfNotExists`, so those members never deploy anything, yet their roles are still granted. Microsoft Cloud Security Benchmark v2 is the most visible example: it grants eight roles, seven of which - including `Contributor`, `User Access Administrator` and `Azure Event Hubs Data Owner` - come only from members hard-coded to `AuditIfNotExists`.
+
+Setting `filterRoleAssignmentsByEffect` to `true` omits a role when it is **only** contributed by member Policies whose effect the Policy Set hard-codes to something other than `DeployIfNotExists` or `Modify`.
+
+```json
+    "filterRoleAssignmentsByEffect": true,
+```
+
+A hard-coded effect is only a default. An assignment may use an [override](policy-assignments.md#defining-overrides-with-json) of kind `policyEffect` to raise a member back to `DeployIfNotExists` or `Modify`, and Azure accepts that even when the Policy Set pins the effect. EPAC therefore keeps the roles of any member an override raises to a deploying effect. Roles are also kept when:
+
+- another member which is not hard-coded contributes the same role, or
+- the assignment has a deploying `policyEffect` override which cannot be attributed to specific `policyDefinitionReferenceId` values.
+
+> [!WARNING]
+> This setting narrows the permissions granted to the Managed Identity, which is a breaking change for existing assignments. It only accounts for overrides defined in your EPAC repository; an override added out of band in the Azure portal is not visible when the deployment plan is calculated (`desiredState` strategies `full` and `ownedOnly` revert such drift anyway). Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
 
 ### Excluding scopes for all Assignments with `globalNotScopes`
 

--- a/Docs/settings-global-setting-file.md
+++ b/Docs/settings-global-setting-file.md
@@ -149,7 +149,9 @@ Policies with `Modify` and `DeployIfNotExists` effects require a Managed Identit
 
 By default the Managed Identity of a Policy Set assignment is granted the union of the `roleDefinitionIds` of **every** member Policy, whatever effect each member evaluates with. Some built-in Policy Sets hard-code a member's effect to a non-deploying value such as `AuditIfNotExists`, so those members never deploy anything, yet their roles are still granted. Microsoft Cloud Security Benchmark v2 is the most visible example: it grants eight roles, seven of which - including `Contributor`, `User Access Administrator` and `Azure Event Hubs Data Owner` - come only from members hard-coded to `AuditIfNotExists`.
 
-Setting `filterRoleAssignmentsByEffect` to `true` omits a role when it is **only** contributed by member Policies whose effect the Policy Set hard-codes to something other than `DeployIfNotExists` or `Modify`.
+Setting `filterRoleAssignmentsByEffect` to `true` omits a role when it is **only** contributed by member Policies whose effect the Policy Set hard-codes to a literal, non-deploying effect: `Audit`, `AuditIfNotExists`, `Deny`, `DenyAction`, `Disabled`, `Append`, `Manual` or `AddToNetworkGroup`.
+
+A Policy Set may also pin a member's effect to an ARM expression, for example `[if(contains(parameters('resourceTypeList'),'microsoft.aad/domainservices'),parameters('effect'),'Disabled')]`. Such an expression is evaluated by Azure at assignment time and can resolve to a deploying effect, so those members always keep their roles. The same applies to any effect value EPAC does not recognise.
 
 ```json
     "filterRoleAssignmentsByEffect": true,
@@ -167,7 +169,11 @@ The setting is deliberately narrow. It does not change:
 - **`additionalRoleAssignments`.** These are read from the Policy Assignment file and appended after the Policy derived roles are calculated. They never pass through the filter, so they are granted in full at the scope you specify. This is what makes them a reliable way to add back a role the filter removes.
 
 > [!WARNING]
-> This setting narrows the permissions granted to the Managed Identity, which is a breaking change for existing assignments. It only accounts for overrides defined in your EPAC repository; an override added out of band in the Azure portal is not visible when the deployment plan is calculated (`desiredState` strategies `full` and `ownedOnly` revert such drift anyway). Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
+> This setting narrows the permissions granted to the Managed Identity. The roles it removes are contributed only by members which cannot deploy anything, so remediation is not affected, but the role assignments themselves are deleted from Azure on the next deployment of the roles plan.
+>
+> One case needs care: the roles are calculated from the **latest** version of the Policy Set, not from the version an assignment pins with `definitionVersion` ([#1394](https://github.com/Azure/enterprise-azure-policy-as-code/issues/1394)). If a member deploys in the pinned version but is hard-coded to a non-deploying effect in the latest version, its role is removed even though the running assignment still needs it. Review the roles plan before deploying when your assignments pin `definitionVersion`.
+>
+> Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
 
 ### Excluding scopes for all Assignments with `globalNotScopes`
 

--- a/Docs/settings-global-setting-file.md
+++ b/Docs/settings-global-setting-file.md
@@ -160,6 +160,12 @@ A hard-coded effect is only a default. An assignment may use an [override](polic
 - another member which is not hard-coded contributes the same role, or
 - the assignment has a deploying `policyEffect` override which cannot be attributed to specific `policyDefinitionReferenceId` values.
 
+The setting is deliberately narrow. It does not change:
+
+- **Assignments of a single Policy.** Only Policy Set assignments are filtered, so a `DeployIfNotExists` or `Modify` Policy assigned on its own always keeps every role its definition declares, even if the assignment overrides it to `Disabled`.
+- **Policy Sets which do not hard-code effects.** When a member takes its effect from its own definition default or from a Policy Set parameter, it is not hard-coded and its roles are always kept.
+- **`additionalRoleAssignments`.** These are read from the Policy Assignment file and appended after the Policy derived roles are calculated. They never pass through the filter, so they are granted in full at the scope you specify. This is what makes them a reliable way to add back a role the filter removes.
+
 > [!WARNING]
 > This setting narrows the permissions granted to the Managed Identity, which is a breaking change for existing assignments. It only accounts for overrides defined in your EPAC repository; an override added out of band in the Azure portal is not visible when the deployment plan is calculated (`desiredState` strategies `full` and `ownedOnly` revert such drift anyway). Use `additionalRoleAssignments` in the Policy Assignment file to add back any role your remediation still needs.
 

--- a/Schemas/global-settings-schema.json
+++ b/Schemas/global-settings-schema.json
@@ -69,8 +69,8 @@
                     },
                     "filterRoleAssignmentsByEffect": {
                         "type": "boolean",
-                        "default": false,
-                        "description": "When true, a Policy Set assignment does not request role assignments which are only contributed by member Policies whose effect the Policy Set hard-codes to a non-deploying value (for example AuditIfNotExists). Members raised back to DeployIfNotExists or Modify by an override still contribute their roles. Defaults to false, which grants the union of all member roles."
+                        "default": true,
+                        "description": "When true, a Policy Set assignment does not request role assignments which are only contributed by member Policies whose effect the Policy Set hard-codes to a non-deploying value (for example AuditIfNotExists). Members raised back to DeployIfNotExists or Modify by an override still contribute their roles. Defaults to true; set it to false to temporarily restore the previous behaviour of granting the union of all member roles."
                     },
                     "defaultContext": {
                         "type": "string",

--- a/Schemas/global-settings-schema.json
+++ b/Schemas/global-settings-schema.json
@@ -67,6 +67,11 @@
                         "default": false,
                         "description": "When true, bypasses the check to see if resources targeted by exemptions actually exist. Improves performance in very large tenants."
                     },
+                    "filterRoleAssignmentsByEffect": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When true, a Policy Set assignment does not request role assignments which are only contributed by member Policies whose effect the Policy Set hard-codes to a non-deploying value (for example AuditIfNotExists). Members raised back to DeployIfNotExists or Modify by an override still contribute their roles. Defaults to false, which grants the union of all member roles."
+                    },
                     "defaultContext": {
                         "type": "string",
                         "description": "The name or ID of a subscription to switch context to before running Resource Graph queries, useful for resolving permission issues in multi-tenant setups."

--- a/Scripts/Helpers/Add-HelperScripts.ps1
+++ b/Scripts/Helpers/Add-HelperScripts.ps1
@@ -73,8 +73,8 @@ $scriptRoot = Split-Path $PSScriptRoot -Parent
 . "$PSScriptRoot/Get-FilteredPolicySetRoleDefinitionIds.ps1"
 . "$PSScriptRoot/Get-GlobalSettings.ps1"
 . "$PSScriptRoot/Get-PacFolders.ps1"
-. "$PSScriptRoot/Get-ParameterNameFromValueString.ps1"
-. "$PSScriptRoot/Get-PolicyAssignmentsDetails.ps1"
+. "$PSScriptRoot/Get-PolicySetVersionedDetails.ps1"
+. "$PSScriptRoot/Get-ParameterNameFromValueString.ps1". "$PSScriptRoot/Get-PolicyAssignmentsDetails.ps1"
 . "$PSScriptRoot/Get-PolicyResourceProperties.ps1"
 . "$PSScriptRoot/Get-ScrubbedString.ps1"
 
@@ -123,6 +123,7 @@ $scriptRoot = Split-Path $PSScriptRoot -Parent
 . "$PSScriptRoot/RestMethods/Get-AzManagementGroupRestMethod.ps1" 
 . "$PSScriptRoot/RestMethods/Get-AzPolicyAssignmentRestMethod.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzPolicyExemptionsRestMethod.ps1"
+. "$PSScriptRoot/RestMethods/Get-AzPolicySetDefinitionVersionsRestMethod.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzResourceListRestMethod.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzRoleAssignmentsRestMethod.ps1"
 . "$PSScriptRoot/RestMethods/Get-AzRoleDefinitionsRestMethod.ps1"

--- a/Scripts/Helpers/Add-HelperScripts.ps1
+++ b/Scripts/Helpers/Add-HelperScripts.ps1
@@ -70,6 +70,7 @@ $scriptRoot = Split-Path $PSScriptRoot -Parent
 . "$PSScriptRoot/Get-DeepCloneAsOrderedHashtable.ps1"
 . "$PSScriptRoot/Get-DefinitionsFullPath.ps1"
 . "$PSScriptRoot/Get-DeploymentPlan.ps1"
+. "$PSScriptRoot/Get-FilteredPolicySetRoleDefinitionIds.ps1"
 . "$PSScriptRoot/Get-GlobalSettings.ps1"
 . "$PSScriptRoot/Get-PacFolders.ps1"
 . "$PSScriptRoot/Get-ParameterNameFromValueString.ps1"

--- a/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
@@ -590,14 +590,39 @@ function Build-AssignmentDefinitionAtLeaf {
         # Calculated after overrides are reconciled, since a CSV effect column replaces the
         # overrides built from the assignment JSON.
         $policyRoleDefinitionIds = $PolicyRoleIds.$policyDefinitionId
-        if ($identityRequired -and $isPolicySet -and $PacEnvironment.filterRoleAssignmentsByEffect) {
-            # Drop the roles only contributed by members the Policy Set pins to a non-deploying
-            # effect, unless an override raises those members back to a deploying effect.
-            $policyRoleDefinitionIds = Get-FilteredPolicySetRoleDefinitionIds `
-                -PolicySetId $policyDefinitionId `
-                -PolicySetDetails $policySetDetails `
-                -PolicyRoleIds $PolicyRoleIds `
-                -OverridesList $baseAssignment.overrides
+        if ($identityRequired -and $isPolicySet) {
+            $effectivePolicySetDetails = $policySetDetails
+
+            # Roles are calculated from the latest version of a Policy Set. When the assignment pins
+            # definitionVersion, the deployed Policy Set is a different version whose members and
+            # hard-coded member effects can differ, so resolve that version instead.
+            if ($baseAssignment.definitionVersion) {
+                if ($null -eq $script:policySetVersionCache) {
+                    $script:policySetVersionCache = @{}
+                }
+                $versioned = Get-PolicySetVersionedDetails `
+                    -PolicySetId $policyDefinitionId `
+                    -DefinitionVersion $baseAssignment.definitionVersion `
+                    -PacEnvironment $PacEnvironment `
+                    -PolicyDetails $policiesDetails `
+                    -PolicyRoleIds $PolicyRoleIds `
+                    -Cache $script:policySetVersionCache
+                if ($null -ne $versioned) {
+                    $effectivePolicySetDetails = $versioned.policySetDetails
+                    $policyRoleDefinitionIds = $versioned.policyRoleDefinitionIds
+                }
+            }
+
+            if ($PacEnvironment.filterRoleAssignmentsByEffect) {
+                # Drop the roles only contributed by members the Policy Set pins to a non-deploying
+                # effect, unless an override raises those members back to a deploying effect.
+                $policyRoleDefinitionIds = Get-FilteredPolicySetRoleDefinitionIds `
+                    -PolicySetId $policyDefinitionId `
+                    -PolicySetDetails $effectivePolicySetDetails `
+                    -PolicyRoleIds $PolicyRoleIds `
+                    -OverridesList $baseAssignment.overrides `
+                    -UnfilteredRoleDefinitionIds $policyRoleDefinitionIds
+            }
         }
 
         #endregion required roleDefinitionIds

--- a/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
+++ b/Scripts/Helpers/Build-AssignmentDefinitionAtLeaf.ps1
@@ -585,6 +585,23 @@ function Build-AssignmentDefinitionAtLeaf {
 
         #endregion Reconcile and deduplicate: CSV, parameters, nonComplianceMessages, and overrides
 
+        #region required roleDefinitionIds
+
+        # Calculated after overrides are reconciled, since a CSV effect column replaces the
+        # overrides built from the assignment JSON.
+        $policyRoleDefinitionIds = $PolicyRoleIds.$policyDefinitionId
+        if ($identityRequired -and $isPolicySet -and $PacEnvironment.filterRoleAssignmentsByEffect) {
+            # Drop the roles only contributed by members the Policy Set pins to a non-deploying
+            # effect, unless an override raises those members back to a deploying effect.
+            $policyRoleDefinitionIds = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $policyDefinitionId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $PolicyRoleIds `
+                -OverridesList $baseAssignment.overrides
+        }
+
+        #endregion required roleDefinitionIds
+
         #region scopeCollection
 
         foreach ($scopeEntry in $scopeCollection) {
@@ -603,7 +620,6 @@ function Build-AssignmentDefinitionAtLeaf {
             if ($identityRequired) {
                 # Add required roleDefinitions (required by Policy definitions)
                 $requiredRoleAssignments = [System.Collections.ArrayList]::new()
-                $policyRoleDefinitionIds = $PolicyRoleIds.$policyDefinitionId
 
                 foreach ($roleDefinitionId in $policyRoleDefinitionIds) {
                     $roleDisplayName = "Unknown"

--- a/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
+++ b/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
@@ -9,7 +9,9 @@ function Get-FilteredPolicySetRoleDefinitionIds {
     roleDefinitionIds of every member Policy, regardless of the effect each member will actually
     evaluate with. Members pinned by the Policy Set to a literal such as AuditIfNotExists never
     deploy anything, so the roles they contribute are not required by the assignment's Managed
-    Identity.
+    Identity. Only a recognised non-deploying effect literal counts as pinned. A Policy Set may also
+    pin an effect to an ARM expression, which evaluates at runtime and may deploy, so those members
+    keep their roles.
 
     A pinned literal is only a default though: an assignment may use an override of kind
     'policyEffect' to raise a member back to a deploying effect. When an override targets a pinned
@@ -36,6 +38,22 @@ function Get-FilteredPolicySetRoleDefinitionIds {
     # Manual is deliberately excluded: no built-in definition combines Manual with roleDefinitionIds.
     $deployingEffects = @("DeployIfNotExists", "Modify")
 
+    # A member only counts as pinned to a non-deploying effect when the Policy Set hard-codes one of
+    # these literals. This must be a whitelist: a Policy Set may pin the effect to an ARM expression
+    # such as [if(contains(parameters('resourceTypeList'),'...'),parameters('effect'),'Disabled')],
+    # which Convert-PolicySetToDetails also reports as "PolicySet Fixed" but which can evaluate to a
+    # deploying effect at runtime. Anything not recognised here keeps its roles.
+    $nonDeployingEffects = @(
+        "AddToNetworkGroup",
+        "Append",
+        "Audit",
+        "AuditIfNotExists",
+        "Deny",
+        "DenyAction",
+        "Disabled",
+        "Manual"
+    )
+
     #region classify members into pinned (non-deploying literal) and unconditional
 
     $pinnedRoleIdsByReferenceId = @{}
@@ -47,7 +65,7 @@ function Get-FilteredPolicySetRoleDefinitionIds {
         }
         $memberRoleIds = $PolicyRoleIds.$policyId
         $isPinnedNonDeploying = $policyInPolicySet.effectReason -eq "PolicySet Fixed" `
-            -and $policyInPolicySet.effectValue -notin $deployingEffects
+            -and $policyInPolicySet.effectValue -in $nonDeployingEffects
         if ($isPinnedNonDeploying) {
             $referenceId = $policyInPolicySet.policyDefinitionReferenceId
             $collected = $pinnedRoleIdsByReferenceId.$referenceId

--- a/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
+++ b/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
@@ -1,0 +1,150 @@
+function Get-FilteredPolicySetRoleDefinitionIds {
+    <#
+    .SYNOPSIS
+    Removes roleDefinitionIds which are only contributed by Policy Set members whose effect the
+    Policy Set hard-codes (pins) to a non-deploying literal value.
+
+    .DESCRIPTION
+    requiredRoleAssignments for a Policy Set assignment is normally the union of the
+    roleDefinitionIds of every member Policy, regardless of the effect each member will actually
+    evaluate with. Members pinned by the Policy Set to a literal such as AuditIfNotExists never
+    deploy anything, so the roles they contribute are not required by the assignment's Managed
+    Identity.
+
+    A pinned literal is only a default though: an assignment may use an override of kind
+    'policyEffect' to raise a member back to a deploying effect. When an override targets a pinned
+    member with DeployIfNotExists or Modify, that member's roles are required again and are kept.
+
+    Only roles contributed exclusively by pinned, non-overridden members are removed. Roles that are
+    also contributed by any other member, or that cannot be attributed to a member, are always kept.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [string] $PolicySetId,
+        $PolicySetDetails,
+        [hashtable] $PolicyRoleIds,
+        $OverridesList
+    )
+
+    $unfilteredRoleDefinitionIds = @($PolicyRoleIds.$PolicySetId)
+    if ($unfilteredRoleDefinitionIds.Count -eq 0 -or $null -eq $PolicySetDetails -or $null -eq $PolicySetDetails.policyDefinitions) {
+        return $unfilteredRoleDefinitionIds
+    }
+
+    # Modify and DeployIfNotExists are the only effects which can require a role assignment.
+    # Manual is deliberately excluded: no built-in definition combines Manual with roleDefinitionIds.
+    $deployingEffects = @("DeployIfNotExists", "Modify")
+
+    #region classify members into pinned (non-deploying literal) and unconditional
+
+    $pinnedRoleIdsByReferenceId = @{}
+    $unconditionalRoleIds = @{}
+    foreach ($policyInPolicySet in $PolicySetDetails.policyDefinitions) {
+        $policyId = $policyInPolicySet.id
+        if (-not $PolicyRoleIds.ContainsKey($policyId)) {
+            continue
+        }
+        $memberRoleIds = $PolicyRoleIds.$policyId
+        $isPinnedNonDeploying = $policyInPolicySet.effectReason -eq "PolicySet Fixed" `
+            -and $policyInPolicySet.effectValue -notin $deployingEffects
+        if ($isPinnedNonDeploying) {
+            $referenceId = $policyInPolicySet.policyDefinitionReferenceId
+            $collected = $pinnedRoleIdsByReferenceId.$referenceId
+            if ($null -eq $collected) {
+                $collected = @{}
+                $null = $pinnedRoleIdsByReferenceId.Add($referenceId, $collected)
+            }
+            foreach ($roleDefinitionId in $memberRoleIds) {
+                $collected[$roleDefinitionId] = $true
+            }
+        }
+        else {
+            foreach ($roleDefinitionId in $memberRoleIds) {
+                $unconditionalRoleIds[$roleDefinitionId] = $true
+            }
+        }
+    }
+
+    if ($pinnedRoleIdsByReferenceId.psbase.Count -eq 0) {
+        return $unfilteredRoleDefinitionIds
+    }
+
+    #endregion classify members
+
+    #region determine which pinned members an override raises to a deploying effect
+
+    $raisedReferenceIds = @{}
+    foreach ($override in $OverridesList) {
+        if ($override.kind -ne "policyEffect" -or $override.value -notin $deployingEffects) {
+            continue
+        }
+        $scopedByReferenceId = $false
+        foreach ($selector in $override.selectors) {
+            if ($selector.kind -ne "policyDefinitionReferenceId") {
+                continue
+            }
+            $scopedByReferenceId = $true
+            if ($null -ne $selector.in) {
+                foreach ($referenceId in $selector.in) {
+                    $raisedReferenceIds[$referenceId] = $true
+                }
+            }
+            elseif ($null -ne $selector.notIn) {
+                $excluded = @{}
+                foreach ($referenceId in $selector.notIn) {
+                    $excluded[$referenceId] = $true
+                }
+                foreach ($referenceId in $pinnedRoleIdsByReferenceId.Keys) {
+                    if (-not $excluded.ContainsKey($referenceId)) {
+                        $raisedReferenceIds[$referenceId] = $true
+                    }
+                }
+            }
+        }
+        if (-not $scopedByReferenceId) {
+            # A deploying override which cannot be attributed to specific members may raise any of
+            # them. Keep every role.
+            return $unfilteredRoleDefinitionIds
+        }
+    }
+
+    #endregion determine raised members
+
+    #region subtract only the roles which no remaining member requires
+
+    $requiredRoleIds = $unconditionalRoleIds.Clone()
+    foreach ($referenceId in $raisedReferenceIds.Keys) {
+        $collected = $pinnedRoleIdsByReferenceId.$referenceId
+        if ($null -ne $collected) {
+            foreach ($roleDefinitionId in $collected.Keys) {
+                $requiredRoleIds[$roleDefinitionId] = $true
+            }
+        }
+    }
+
+    $removableRoleIds = @{}
+    foreach ($referenceId in $pinnedRoleIdsByReferenceId.Keys) {
+        foreach ($roleDefinitionId in $pinnedRoleIdsByReferenceId.$referenceId.Keys) {
+            if (-not $requiredRoleIds.ContainsKey($roleDefinitionId)) {
+                $removableRoleIds[$roleDefinitionId] = $true
+            }
+        }
+    }
+
+    if ($removableRoleIds.psbase.Count -eq 0) {
+        return $unfilteredRoleDefinitionIds
+    }
+
+    # Filter the original union so unattributed roles and the original ordering are preserved.
+    $filteredRoleDefinitionIds = [System.Collections.ArrayList]::new()
+    foreach ($roleDefinitionId in $unfilteredRoleDefinitionIds) {
+        if (-not $removableRoleIds.ContainsKey($roleDefinitionId)) {
+            $null = $filteredRoleDefinitionIds.Add($roleDefinitionId)
+        }
+    }
+
+    #endregion subtract roles
+
+    return $filteredRoleDefinitionIds.ToArray()
+}

--- a/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
+++ b/Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1
@@ -26,10 +26,17 @@ function Get-FilteredPolicySetRoleDefinitionIds {
         [string] $PolicySetId,
         $PolicySetDetails,
         [hashtable] $PolicyRoleIds,
-        $OverridesList
+        $OverridesList,
+
+        # Supplied when the assignment pins a definitionVersion, so the roles to filter are the union
+        # calculated for that version rather than for the latest version in $PolicyRoleIds.
+        $UnfilteredRoleDefinitionIds = $null
     )
 
     $unfilteredRoleDefinitionIds = @($PolicyRoleIds.$PolicySetId)
+    if ($null -ne $UnfilteredRoleDefinitionIds) {
+        $unfilteredRoleDefinitionIds = @($UnfilteredRoleDefinitionIds)
+    }
     if ($unfilteredRoleDefinitionIds.Count -eq 0 -or $null -eq $PolicySetDetails -or $null -eq $PolicySetDetails.policyDefinitions) {
         return $unfilteredRoleDefinitionIds
     }

--- a/Scripts/Helpers/Get-GlobalSettings.ps1
+++ b/Scripts/Helpers/Get-GlobalSettings.ps1
@@ -182,10 +182,12 @@ function Get-GlobalSettings {
                 $skipResourceValidationForExemptions = $true
             }
 
-            $filterRoleAssignmentsByEffect = $false
+            # Defaults to true. An explicit false is the opt-out for repositories which need the
+            # previous behaviour of granting every member Policy's roles.
+            $filterRoleAssignmentsByEffect = $true
             $filterRoleAssignmentsByEffectRaw = $pacEnvironment.filterRoleAssignmentsByEffect
-            if ($filterRoleAssignmentsByEffectRaw) {
-                $filterRoleAssignmentsByEffect = $true
+            if ($null -ne $filterRoleAssignmentsByEffectRaw) {
+                $filterRoleAssignmentsByEffect = [bool] $filterRoleAssignmentsByEffectRaw
             }
 
             $desiredState = @{

--- a/Scripts/Helpers/Get-GlobalSettings.ps1
+++ b/Scripts/Helpers/Get-GlobalSettings.ps1
@@ -182,6 +182,12 @@ function Get-GlobalSettings {
                 $skipResourceValidationForExemptions = $true
             }
 
+            $filterRoleAssignmentsByEffect = $false
+            $filterRoleAssignmentsByEffectRaw = $pacEnvironment.filterRoleAssignmentsByEffect
+            if ($filterRoleAssignmentsByEffectRaw) {
+                $filterRoleAssignmentsByEffect = $true
+            }
+
             $desiredState = @{
                 strategy                             = "undefined"
                 keepDfcSecurityAssignments           = $false
@@ -374,6 +380,7 @@ function Get-GlobalSettings {
                 defaultContext                      = $defaultContext
                 policyDefinitionsScopes             = $policyDefinitionsScopes
                 skipResourceValidationForExemptions = $skipResourceValidationForExemptions
+                filterRoleAssignmentsByEffect       = $filterRoleAssignmentsByEffect
                 doNotDisableDeprecatedPolicies      = $doNotDisableDeprecatedPolicies
                 desiredState                        = $desiredState
                 managedIdentityLocation             = $managedIdentityLocation

--- a/Scripts/Helpers/Get-PolicySetVersionedDetails.ps1
+++ b/Scripts/Helpers/Get-PolicySetVersionedDetails.ps1
@@ -1,0 +1,216 @@
+function Get-PolicySetVersionedDetails {
+    <#
+    .SYNOPSIS
+    Resolves a Policy Set assignment's definitionVersion to a concrete published version and returns
+    the member details and required roleDefinitionIds for that version.
+
+    .DESCRIPTION
+    EPAC reads deployed Policy Set definitions at their latest version. An assignment which pins
+    definitionVersion runs a different version, whose member list and hard-coded member effects can
+    differ. Calculating the Managed Identity roles from the latest version therefore grants the wrong
+    roles: roles can be missing for members which only deploy in the pinned version.
+
+    This resolves the pinned version from the Policy Set's published version history and recomputes
+    both the member details and the role union against it.
+
+    Resolution follows the wildcard forms EPAC's assignment schema allows, 'XX.*.*' and 'XX.XX.*', and
+    also accepts an exact version. Stable versions are preferred; a pre-release version is only
+    selected when no stable version matches the requested pattern.
+
+    Any failure to resolve - no version history, an unmatched pattern or a REST error - returns $null
+    so the caller falls back to the latest definition and its unfiltered roles.
+
+    .PARAMETER PolicySetId
+    Resource id of the Policy Set definition.
+
+    .PARAMETER DefinitionVersion
+    The version or version wildcard pinned by the assignment.
+
+    .PARAMETER PacEnvironment
+    The pacEnvironment, used for the policySetDefinitionVersions API version.
+
+    .PARAMETER PolicyDetails
+    Policy details hashtable keyed by Policy definition id, as produced by Convert-PolicyResourcesToDetails.
+
+    .PARAMETER PolicyRoleIds
+    Hashtable of definition id to roleDefinitionIds, used to build the member role union.
+
+    .PARAMETER Cache
+    Hashtable used to memoize version history lookups across assignments in one build.
+
+    .OUTPUTS
+    Hashtable with policySetDetails, policyRoleDefinitionIds and resolvedVersion, or $null.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $PolicySetId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $DefinitionVersion,
+
+        [Parameter(Mandatory = $true)]
+        $PacEnvironment,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable] $PolicyDetails,
+
+        [Parameter(Mandatory = $true)]
+        $PolicyRoleIds,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable] $Cache = $null
+    )
+
+    #region retrieve version history
+
+    $versions = $null
+    if ($null -ne $Cache -and $Cache.ContainsKey($PolicySetId)) {
+        $versions = $Cache.$PolicySetId
+    }
+    else {
+        $apiVersion = $PacEnvironment.apiVersions.policySetDefinitionVersions
+        if (-not $apiVersion) {
+            $apiVersion = $PacEnvironment.apiVersions.policySetDefinitions
+        }
+        $versions = Get-AzPolicySetDefinitionVersionsRestMethod -PolicySetId $PolicySetId -ApiVersion $apiVersion
+        if ($null -ne $Cache) {
+            $Cache[$PolicySetId] = $versions
+        }
+    }
+
+    if ($null -eq $versions -or @($versions).Count -eq 0) {
+        return $null
+    }
+
+    #endregion retrieve version history
+
+    #region resolve the requested version
+
+    # A pattern may carry a pre-release suffix, for example '1.*.*-preview', which opts the
+    # assignment in to pre-release versions of the matching line.
+    $pattern = $DefinitionVersion
+    $preReleaseRequested = $false
+    $patternDashIndex = $pattern.IndexOf("-")
+    if ($patternDashIndex -ge 0) {
+        $pattern = $pattern.Substring(0, $patternDashIndex)
+        $preReleaseRequested = $true
+    }
+
+    $patternSegments = $pattern.Split(".")
+    $stableMatches = [System.Collections.ArrayList]::new()
+    $preReleaseMatches = [System.Collections.ArrayList]::new()
+
+    foreach ($candidate in $versions) {
+        $name = $candidate.name
+        if (-not $name) {
+            continue
+        }
+
+        # Split '1.3.0-preview' into the numeric core '1.3.0' and the pre-release label 'preview'.
+        $core = $name
+        $isPreRelease = $false
+        $dashIndex = $name.IndexOf("-")
+        if ($dashIndex -ge 0) {
+            $core = $name.Substring(0, $dashIndex)
+            $isPreRelease = $true
+        }
+
+        $coreSegments = $core.Split(".")
+        if ($coreSegments.Count -ne $patternSegments.Count) {
+            continue
+        }
+
+        $isMatch = $true
+        for ($i = 0; $i -lt $patternSegments.Count; $i++) {
+            if ($patternSegments[$i] -eq "*") {
+                continue
+            }
+            if ($patternSegments[$i] -ne $coreSegments[$i]) {
+                $isMatch = $false
+                break
+            }
+        }
+        if (-not $isMatch) {
+            continue
+        }
+
+        $sortableVersion = $null
+        if (-not [System.Version]::TryParse($core, [ref] $sortableVersion)) {
+            continue
+        }
+
+        $entry = @{
+            definition   = $candidate
+            version      = $sortableVersion
+            name         = $name
+            isPreRelease = $isPreRelease
+        }
+        if ($isPreRelease) {
+            $null = $preReleaseMatches.Add($entry)
+        }
+        else {
+            $null = $stableMatches.Add($entry)
+        }
+    }
+
+    # A pre-release is only used when the requested pattern matches nothing stable, unless the
+    # pattern explicitly asked for pre-releases.
+    $candidates = $stableMatches
+    if ($preReleaseRequested) {
+        $candidates = [System.Collections.ArrayList]::new()
+        $candidates.AddRange($stableMatches)
+        $candidates.AddRange($preReleaseMatches)
+    }
+    if ($candidates.Count -eq 0) {
+        $candidates = $preReleaseMatches
+    }
+    if ($candidates.Count -eq 0) {
+        Write-Verbose "No published version of '$PolicySetId' matches definitionVersion '$DefinitionVersion'"
+        return $null
+    }
+
+    # Ties between a stable and a pre-release of the same core version favour the pre-release only
+    # when the pattern asked for one.
+    $resolved = $candidates |
+        Sort-Object -Property @{ Expression = { $_.version } }, @{ Expression = { $_.isPreRelease -eq $preReleaseRequested } } -Descending |
+        Select-Object -First 1
+
+    #endregion resolve the requested version
+
+    #region calculate details and roles for the resolved version
+
+    $versionedDetails = @{}
+    Convert-PolicySetToDetails `
+        -PolicySetId $PolicySetId `
+        -PolicySetDefinition $resolved.definition `
+        -PolicySetDetails $versionedDetails `
+        -PolicyDetails $PolicyDetails
+
+    $policySetDetails = $versionedDetails.$PolicySetId
+    if ($null -eq $policySetDetails) {
+        return $null
+    }
+
+    # Union the roles of the members present in this version, matching how Build-DeploymentPlans
+    # calculates the role union for the latest version.
+    $roleIds = [ordered]@{}
+    $properties = Get-PolicyResourceProperties -PolicyResource $resolved.definition
+    foreach ($policyInPolicySet in $properties.policyDefinitions) {
+        $policyId = $policyInPolicySet.policyDefinitionId
+        if ($PolicyRoleIds.ContainsKey($policyId)) {
+            foreach ($roleDefinitionId in $PolicyRoleIds.$policyId) {
+                $roleIds[$roleDefinitionId] = "added"
+            }
+        }
+    }
+
+    return @{
+        policySetDetails        = $policySetDetails
+        policyRoleDefinitionIds = @($roleIds.Keys)
+        resolvedVersion         = $resolved.name
+    }
+
+    #endregion calculate details and roles for the resolved version
+}

--- a/Scripts/Helpers/RestMethods/Get-AzPolicySetDefinitionVersionsRestMethod.ps1
+++ b/Scripts/Helpers/RestMethods/Get-AzPolicySetDefinitionVersionsRestMethod.ps1
@@ -1,0 +1,30 @@
+function Get-AzPolicySetDefinitionVersionsRestMethod {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $PolicySetId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ApiVersion
+    )
+
+    # Versions are only exposed for Policy Sets which publish a version history. Built-in Policy Sets
+    # always do; custom Policy Sets may not. A missing or inaccessible versions endpoint is not an
+    # error condition, so return $null and let the caller fall back to the latest definition.
+    try {
+        $response = Invoke-AzRestMethod -Path "$($PolicySetId)/versions?api-version=$ApiVersion" -Method GET
+    }
+    catch {
+        Write-Verbose "Get Policy Set versions failed for '$PolicySetId' -- $($_.Exception.Message)"
+        return $null
+    }
+
+    $statusCode = $response.StatusCode
+    if ($statusCode -lt 200 -or $statusCode -ge 300) {
+        Write-Verbose "Get Policy Set versions returned $statusCode for '$PolicySetId' -- $($response.Content)"
+        return $null
+    }
+
+    $content = $response.Content | ConvertFrom-Json -Depth 100
+    return $content.value
+}

--- a/Scripts/Helpers/Select-PacEnvironment.ps1
+++ b/Scripts/Helpers/Select-PacEnvironment.ps1
@@ -65,32 +65,35 @@ function Select-PacEnvironment {
     $apiVersions = switch ($pacEnvironment.cloud) {
         AzureChinaCloud {
             @{
-                policyDefinitions    = "2021-06-01"
-                policySetDefinitions = "2023-04-01"
-                policyAssignments    = "2022-06-01"
-                policyExemptions     = "2022-07-01-preview"
-                policyEnrollments    = "2026-01-01-preview"
-                roleAssignments      = "2022-04-01"
+                policyDefinitions           = "2021-06-01"
+                policySetDefinitions        = "2023-04-01"
+                policySetDefinitionVersions = "2023-04-01"
+                policyAssignments           = "2022-06-01"
+                policyExemptions            = "2022-07-01-preview"
+                policyEnrollments           = "2026-01-01-preview"
+                roleAssignments             = "2022-04-01"
             }
         }
         AzureUSGovernment {
             @{
-                policyDefinitions    = "2023-04-01"
-                policySetDefinitions = "2023-04-01"
-                policyAssignments    = "2023-04-01"
-                policyExemptions     = "2024-12-01-preview"
-                policyEnrollments    = "2026-01-01-preview"
-                roleAssignments      = "2022-04-01"
+                policyDefinitions           = "2023-04-01"
+                policySetDefinitions        = "2023-04-01"
+                policySetDefinitionVersions = "2023-04-01"
+                policyAssignments           = "2023-04-01"
+                policyExemptions            = "2024-12-01-preview"
+                policyEnrollments           = "2026-01-01-preview"
+                roleAssignments             = "2022-04-01"
             }
         }
         default {
             @{
-                policyDefinitions    = "2023-04-01"
-                policySetDefinitions = "2023-04-01"
-                policyAssignments    = "2023-04-01"
-                policyExemptions     = "2022-07-01-preview"
-                policyEnrollments    = "2026-01-01-preview"
-                roleAssignments      = "2022-04-01"
+                policyDefinitions           = "2023-04-01"
+                policySetDefinitions        = "2023-04-01"
+                policySetDefinitionVersions = "2023-04-01"
+                policyAssignments           = "2023-04-01"
+                policyExemptions            = "2022-07-01-preview"
+                policyEnrollments           = "2026-01-01-preview"
+                roleAssignments             = "2022-04-01"
             }
         }
     }

--- a/Tests/Helpers/Unit/Get-FilteredPolicySetRoleDefinitionIds.Tests.ps1
+++ b/Tests/Helpers/Unit/Get-FilteredPolicySetRoleDefinitionIds.Tests.ps1
@@ -47,6 +47,78 @@ BeforeAll {
 
 Describe 'Get-FilteredPolicySetRoleDefinitionIds' {
 
+    Context 'members whose pinned effect is not a recognised non-deploying literal' {
+
+        BeforeEach {
+            $script:policyRoleIds = @{
+                $script:policySetId    = @( $script:eventHubRole )
+                $script:pinnedPolicyId = @( $script:eventHubRole )
+            }
+        }
+
+        It 'keeps roles when the Policy Set pins the effect to an ARM expression' {
+            # Built-in diagnostic settings Policy Sets pin member effects to an expression which
+            # evaluates to parameters('effect'), defaulting to DeployIfNotExists, so the roles are
+            # genuinely required. Convert-PolicySetToDetails still reports these as PolicySet Fixed.
+            $armExpression = "[if(contains(parameters('resourceTypeList'),'microsoft.aad/domainservices'),parameters('effect'),'Disabled')]"
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'expressionRef' -EffectReason 'PolicySet Fixed' -EffectValue $armExpression
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'keeps roles when the pinned effect is an unrecognised value' {
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'unknownRef' -EffectReason 'PolicySet Fixed' -EffectValue 'SomeFutureEffect'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'removes roles for every recognised non-deploying literal' -ForEach @(
+            @{ Effect = 'Audit' }
+            @{ Effect = 'AuditIfNotExists' }
+            @{ Effect = 'Deny' }
+            @{ Effect = 'DenyAction' }
+            @{ Effect = 'Disabled' }
+            @{ Effect = 'Append' }
+            @{ Effect = 'Manual' }
+            @{ Effect = 'AddToNetworkGroup' }
+            @{ Effect = 'auditifnotexists' }
+        ) {
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue $Effect
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
     Context 'members pinned by the Policy Set to a non-deploying effect' {
 
         BeforeEach {

--- a/Tests/Helpers/Unit/Get-FilteredPolicySetRoleDefinitionIds.Tests.ps1
+++ b/Tests/Helpers/Unit/Get-FilteredPolicySetRoleDefinitionIds.Tests.ps1
@@ -1,0 +1,282 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/Get-FilteredPolicySetRoleDefinitionIds.ps1')
+
+    $script:policySetId = '/providers/Microsoft.Authorization/policySetDefinitions/test-set'
+    $script:eventHubRole = '/providers/Microsoft.Authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec'
+    $script:laRole = '/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293'
+    $script:uaaRole = '/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+
+    $script:pinnedPolicyId = '/providers/Microsoft.Authorization/policyDefinitions/pinned'
+    $script:openPolicyId = '/providers/Microsoft.Authorization/policyDefinitions/open'
+
+    function New-Member {
+        param (
+            [string] $PolicyId,
+            [string] $ReferenceId,
+            [string] $EffectReason,
+            [string] $EffectValue
+        )
+        @{
+            id                          = $PolicyId
+            policyDefinitionReferenceId = $ReferenceId
+            effectReason                = $EffectReason
+            effectValue                 = $EffectValue
+        }
+    }
+
+    function New-Override {
+        param (
+            [string] $Value,
+            [string[]] $In,
+            [string[]] $NotIn,
+            [switch] $NoSelectors
+        )
+        $override = @{
+            kind  = 'policyEffect'
+            value = $Value
+        }
+        if (-not $NoSelectors) {
+            $selector = @{ kind = 'policyDefinitionReferenceId' }
+            if ($In) { $selector.in = $In }
+            if ($NotIn) { $selector.notIn = $NotIn }
+            $override.selectors = @( $selector )
+        }
+        $override
+    }
+}
+
+Describe 'Get-FilteredPolicySetRoleDefinitionIds' {
+
+    Context 'members pinned by the Policy Set to a non-deploying effect' {
+
+        BeforeEach {
+            $script:policyRoleIds = @{
+                $script:policySetId   = @( $script:eventHubRole )
+                $script:pinnedPolicyId = @( $script:eventHubRole )
+            }
+            $script:policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue 'AuditIfNotExists'
+                )
+            }
+        }
+
+        It 'removes roles only contributed by the pinned member' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'keeps the role when an in selector override raises the member to DeployIfNotExists' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'DeployIfNotExists' -In @('pinnedRef')) )
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'keeps the role when a notIn selector override leaves the member raised' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'Modify' -NotIn @('someOtherRef')) )
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'removes the role when a notIn selector override excludes the member' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'DeployIfNotExists' -NotIn @('pinnedRef')) )
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'removes the role when the override targets a different member' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'DeployIfNotExists' -In @('unrelatedRef')) )
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'removes the role when the override sets a non-deploying effect' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'Disabled' -In @('pinnedRef')) )
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'never treats Manual as a deploying effect' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'Manual' -In @('pinnedRef')) )
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'keeps every role when a deploying override cannot be attributed to a member' {
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $script:policySetDetails `
+                -PolicyRoleIds $script:policyRoleIds `
+                -OverridesList @( (New-Override -Value 'DeployIfNotExists' -NoSelectors) )
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+    }
+
+    Context 'members which are not pinned to a non-deploying effect' {
+
+        It 'keeps roles when the Policy Set pins a deploying effect' {
+            $policyRoleIds = @{
+                $script:policySetId    = @( $script:eventHubRole )
+                $script:pinnedPolicyId = @( $script:eventHubRole )
+            }
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue 'DeployIfNotExists'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'keeps roles when the effect is parameterized by the Policy Set' {
+            $policyRoleIds = @{
+                $script:policySetId  = @( $script:laRole )
+                $script:openPolicyId = @( $script:laRole )
+            }
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:openPolicyId -ReferenceId 'openRef' -EffectReason 'PolicySet Default' -EffectValue 'AuditIfNotExists'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:laRole )
+        }
+    }
+
+    Context 'roles contributed by more than one member' {
+
+        It 'keeps a role which a non-pinned member also contributes' {
+            $policyRoleIds = @{
+                $script:policySetId    = @( $script:laRole, $script:eventHubRole )
+                $script:pinnedPolicyId = @( $script:laRole, $script:eventHubRole )
+                $script:openPolicyId   = @( $script:laRole )
+            }
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue 'AuditIfNotExists'
+                    New-Member -PolicyId $script:openPolicyId -ReferenceId 'openRef' -EffectReason 'PolicySet Default' -EffectValue 'AuditIfNotExists'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:laRole )
+        }
+
+        It 'keeps a role which another pinned but overridden member contributes' {
+            $secondPinnedPolicyId = '/providers/Microsoft.Authorization/policyDefinitions/pinned2'
+            $policyRoleIds = @{
+                $script:policySetId    = @( $script:uaaRole, $script:eventHubRole )
+                $script:pinnedPolicyId = @( $script:uaaRole )
+                $secondPinnedPolicyId  = @( $script:uaaRole, $script:eventHubRole )
+            }
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue 'AuditIfNotExists'
+                    New-Member -PolicyId $secondPinnedPolicyId -ReferenceId 'pinnedRef2' -EffectReason 'PolicySet Fixed' -EffectValue 'AuditIfNotExists'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @( (New-Override -Value 'DeployIfNotExists' -In @('pinnedRef')) )
+
+            # pinnedRef is raised so uaaRole is required; eventHubRole is only required by the
+            # still pinned pinnedRef2 and is removed.
+            $result | Should -Be @( $script:uaaRole )
+        }
+    }
+
+    Context 'safety fallbacks' {
+
+        It 'returns the unfiltered union when the Policy Set has no roles' {
+            $policyRoleIds = @{}
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails @{ policyDefinitions = @() } `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'returns the unfiltered union when no Policy Set details are available' {
+            $policyRoleIds = @{ $script:policySetId = @( $script:eventHubRole ) }
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $null `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:eventHubRole )
+        }
+
+        It 'keeps a role which cannot be attributed to any member' {
+            $policyRoleIds = @{
+                $script:policySetId    = @( $script:eventHubRole, $script:laRole )
+                $script:pinnedPolicyId = @( $script:eventHubRole )
+            }
+            $policySetDetails = @{
+                policyDefinitions = @(
+                    New-Member -PolicyId $script:pinnedPolicyId -ReferenceId 'pinnedRef' -EffectReason 'PolicySet Fixed' -EffectValue 'AuditIfNotExists'
+                )
+            }
+
+            $result = Get-FilteredPolicySetRoleDefinitionIds `
+                -PolicySetId $script:policySetId `
+                -PolicySetDetails $policySetDetails `
+                -PolicyRoleIds $policyRoleIds `
+                -OverridesList @()
+
+            $result | Should -Be @( $script:laRole )
+        }
+    }
+}

--- a/Tests/Helpers/Unit/Get-PolicySetVersionedDetails.Tests.ps1
+++ b/Tests/Helpers/Unit/Get-PolicySetVersionedDetails.Tests.ps1
@@ -1,0 +1,275 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/Get-PolicySetVersionedDetails.ps1')
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/Get-PolicyResourceProperties.ps1')
+    . (Join-Path $PSScriptRoot '../../../Scripts/Helpers/RestMethods/Get-AzPolicySetDefinitionVersionsRestMethod.ps1')
+
+    # Convert-PolicySetToDetails writes into the accumulator hashtable it is handed.
+    function script:Convert-PolicySetToDetails {
+        param ($PolicySetId, $PolicySetDefinition, $PolicySetDetails, $PolicyDetails)
+        $PolicySetDetails[$PolicySetId] = @{
+            id      = $PolicySetId
+            version = $PolicySetDefinition.name
+        }
+    }
+
+    $script:policySetId = '/providers/Microsoft.Authorization/policySetDefinitions/test-set'
+    $script:memberA = '/providers/Microsoft.Authorization/policyDefinitions/member-a'
+    $script:memberB = '/providers/Microsoft.Authorization/policyDefinitions/member-b'
+    $script:roleA = '/providers/Microsoft.Authorization/roleDefinitions/aaaaaaaa-0000-0000-0000-000000000000'
+    $script:roleB = '/providers/Microsoft.Authorization/roleDefinitions/bbbbbbbb-0000-0000-0000-000000000000'
+
+    $script:pacEnvironment = @{
+        apiVersions = @{
+            policySetDefinitionVersions = '2023-04-01'
+            policySetDefinitions        = '2023-04-01'
+        }
+    }
+
+    $script:policyRoleIds = @{
+        $script:memberA = @( $script:roleA )
+        $script:memberB = @( $script:roleB )
+    }
+
+    function New-Version {
+        param (
+            [string] $Name,
+            [string[]] $Members
+        )
+        @{
+            name       = $Name
+            properties = @{
+                policyDefinitions = @( $Members | ForEach-Object { @{ policyDefinitionId = $_ } } )
+            }
+        }
+    }
+}
+
+Describe 'Get-PolicySetVersionedDetails' {
+
+    BeforeEach {
+        $script:allVersions = @(
+            New-Version -Name '1.0.0-preview' -Members @( $script:memberA )
+            New-Version -Name '1.3.0-preview' -Members @( $script:memberA )
+            New-Version -Name '1.4.0' -Members @( $script:memberA, $script:memberB )
+            New-Version -Name '1.7.0' -Members @( $script:memberA, $script:memberB )
+            New-Version -Name '2.0.0' -Members @( $script:memberB )
+        )
+
+        Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+    }
+
+    Context 'wildcard resolution' {
+
+        It 'resolves XX.*.* to the highest matching stable version' {
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.7.0'
+            $result.policyRoleDefinitionIds | Should -Be @( $script:roleA, $script:roleB )
+        }
+
+        It 'resolves XX.XX.* to the matching minor version' {
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.4.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.4.0'
+        }
+
+        It 'resolves an exact version' {
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '2.0.0' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '2.0.0'
+            $result.policyRoleDefinitionIds | Should -Be @( $script:roleB )
+        }
+    }
+
+    Context 'pre-release handling' {
+
+        It 'prefers a stable version over a higher pre-release' {
+            $script:allVersions = @(
+                New-Version -Name '1.4.0' -Members @( $script:memberA )
+                New-Version -Name '1.5.0-preview' -Members @( $script:memberB )
+            )
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.4.0'
+        }
+
+        It 'falls back to a pre-release when no stable version matches' {
+            # Microsoft cloud security benchmark v2 only published 1.3.0-preview for the 1.3 line.
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.3.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.3.0-preview'
+            $result.policyRoleDefinitionIds | Should -Be @( $script:roleA )
+        }
+
+        It 'includes pre-releases when the pattern carries a pre-release suffix' {
+            $script:allVersions = @(
+                New-Version -Name '1.4.0' -Members @( $script:memberA )
+                New-Version -Name '1.5.0-preview' -Members @( $script:memberB )
+            )
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*-preview' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.5.0-preview'
+        }
+
+        It 'prefers a pre-release over the same stable core version when one is requested' {
+            $script:allVersions = @(
+                New-Version -Name '1.4.0' -Members @( $script:memberA )
+                New-Version -Name '1.4.0-preview' -Members @( $script:memberB )
+            )
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*-preview' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.resolvedVersion | Should -Be '1.4.0-preview'
+        }
+    }
+
+    Context 'conservative fallbacks' {
+
+        It 'returns null when no published version matches' {
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '9.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'returns null when the versions endpoint is unavailable' {
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $null }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'returns null when the Policy Set has no version history' {
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { @() }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'ignores members which contribute no roles' {
+            $script:allVersions = @(
+                New-Version -Name '1.0.0' -Members @( '/providers/Microsoft.Authorization/policyDefinitions/audit-only' )
+            )
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $script:policyRoleIds
+
+            $result.policyRoleDefinitionIds | Should -BeNullOrEmpty
+        }
+
+        It 'de-duplicates roles contributed by more than one member' {
+            $script:allVersions = @(
+                New-Version -Name '1.0.0' -Members @( $script:memberA, $script:memberB )
+            )
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $script:allVersions }
+            $duplicateRoleIds = @{
+                $script:memberA = @( $script:roleA )
+                $script:memberB = @( $script:roleA )
+            }
+
+            $result = Get-PolicySetVersionedDetails `
+                -PolicySetId $script:policySetId `
+                -DefinitionVersion '1.*.*' `
+                -PacEnvironment $script:pacEnvironment `
+                -PolicyDetails @{} `
+                -PolicyRoleIds $duplicateRoleIds
+
+            @($result.policyRoleDefinitionIds).Count | Should -Be 1
+        }
+    }
+
+    Context 'caching' {
+
+        It 'only queries the versions endpoint once per Policy Set' {
+            $cache = @{}
+            1..3 | ForEach-Object {
+                $null = Get-PolicySetVersionedDetails `
+                    -PolicySetId $script:policySetId `
+                    -DefinitionVersion '1.*.*' `
+                    -PacEnvironment $script:pacEnvironment `
+                    -PolicyDetails @{} `
+                    -PolicyRoleIds $script:policyRoleIds `
+                    -Cache $cache
+            }
+
+            Should -Invoke Get-AzPolicySetDefinitionVersionsRestMethod -Times 1 -Exactly
+        }
+
+        It 'caches an unavailable versions endpoint so it is not retried' {
+            Mock Get-AzPolicySetDefinitionVersionsRestMethod { $null }
+            $cache = @{}
+            1..3 | ForEach-Object {
+                $null = Get-PolicySetVersionedDetails `
+                    -PolicySetId $script:policySetId `
+                    -DefinitionVersion '1.*.*' `
+                    -PacEnvironment $script:pacEnvironment `
+                    -PolicyDetails @{} `
+                    -PolicyRoleIds $script:policyRoleIds `
+                    -Cache $cache
+            }
+
+            Should -Invoke Get-AzPolicySetDefinitionVersionsRestMethod -Times 1 -Exactly
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #1393

## Why

A Policy Set assignment's Managed Identity is granted the union of the `roleDefinitionIds` of **every** member Policy, regardless of the effect each member actually evaluates with. Many built-in Policy Sets hard-code a member's effect to a non-deploying literal such as `AuditIfNotExists`, so those members can never deploy anything, yet their roles are still granted at management group scope.

Microsoft cloud security benchmark v2 is the clearest case: it requests 8 roles, and 7 of them - including `Contributor`, `User Access Administrator` and `Azure Event Hubs Data Owner` - come only from members hard-coded to `AuditIfNotExists`. Only `Log Analytics Contributor` is reachable.

While validating a fix, a second defect surfaced (#1394): roles are calculated from the **latest** published version of a Policy Set even when the assignment pins `definitionVersion`. Members and hard-coded member effects change between versions, so both the role union and any effect-based filtering were being evaluated against a definition the assignment does not run. That had to be fixed first, otherwise filtering by effect would strip roles a version-pinned assignment genuinely needs.

## Approach

**Effect-aware role filtering** (`Get-FilteredPolicySetRoleDefinitionIds.ps1`)

A role is dropped only when it is *exclusively* contributed by members the Policy Set pins to a recognised non-deploying literal (`Audit`, `AuditIfNotExists`, `Deny`, `DenyAction`, `Disabled`, `Append`, `Manual`, `AddToNetworkGroup`).

The classification is deliberately a whitelist rather than a blacklist. A Policy Set can also pin an effect to an ARM expression such as `[if(contains(parameters('resourceTypeList'),'...'),parameters('effect'),'Disabled')]`, which EPAC also reports as "PolicySet Fixed" but which Azure evaluates at assignment time and can resolve to a deploying effect. An early blacklist implementation misclassified those and zeroed the roles on 7 Policy Sets, including the ALZ `Enable allLogs` diagnostic families. The whitelist keeps roles for anything not positively recognised as non-deploying.

A hard-coded effect is only a *default*. An assignment can use a `policyEffect` override to raise a member back to `DeployIfNotExists` or `Modify`, and Azure accepts that even when the Policy Set pins the effect (confirmed live in the portal, not just from docs). The filter therefore resolves `in` / `notIn` reference-id selectors and keeps the roles of any member an override raises. An unattributable deploying override keeps every role.

**Version-aware role calculation** (`Get-PolicySetVersionedDetails.ps1`, fixes #1394)

When an assignment pins `definitionVersion`, EPAC now resolves that version from the Policy Set's published version history and recalculates both the member details and the role union against it. Wildcards resolve to the highest match, preferring stable unless the pattern carries a pre-release suffix or nothing stable matches. Version history is cached per Policy Set for the duration of a build, so this is one extra REST call per version-pinned Policy Set.

This applies regardless of the filter flag, since it is the underlying defect.

**Default**

With #1394 fixed, `filterRoleAssignmentsByEffect` defaults to `true`. An explicit `false` is still honoured as a temporary opt-out.

## Things worth a careful look

- **Every failure path falls back to "keep all roles."** No version history, an unmatched pattern, a REST error, a cloud that does not expose `/versions` - all return `$null` and use the latest definition unfiltered. The change can reduce over-granting but should never create a new under-grant.
- **This deletes live role assignments** for existing MCSB v2 assignees on the next roles deploy. Those roles are contributed only by members that cannot remediate, so nothing functional should depend on them, but it is a visible change in Azure.
- **Version-pinned assignments may see roles change even with filtering off**, because the version-correct union is now used. Documented.
- **`additionalRoleAssignments` is untouched.** It is appended after the Policy-derived roles are calculated and never passes through the filter, which makes it the reliable escape hatch for adding a role back.

## Validation

Blast radius over the full built-in catalogue (3,685 definitions, 187 Policy Sets), invoking the real filter against every role-granting set:

| Check | Result |
|---|---|
| Role-granting built-in Policy Sets affected | 1 of 113 (MCSB v2, 8 -> 1) |
| Pester | 119/119 pass (26 + 12 new tests) |

Live against a real management group, with a 14-assignment regression matrix covering standalone DINE/Modify policies, a DINE policy overridden to `Disabled`, multi-role policies, Policy Sets with no pinned effects, Policy Sets with parameter-reference effects, `additionalRoleAssignments` at both MG and subscription scope, and a portal-accepted override raising a pinned member to DINE:

| Assignment | Result |
|---|---|
| MCSB v2 (latest) | 8 roles -> 1 (`Log Analytics Contributor`) |
| MCSB v2 with DINE override | 3 roles retained, correctly attributed to the raised members |
| MCSB v2 pinned `1.3.*` | full 7-role union retained; this is the #1394 fix, it would have been 1 |
| MCSB v2 pinned `1.7.*` | reduces to `Log Analytics Contributor` |
| Other 11 regression assignments | unchanged |

## Follow-up not included here

A Policy Set *member* can itself pin a `definitionVersion` (`policy-set-definition-schema.json`), and that is still resolved at latest. Deliberately out of scope; worth a separate issue.